### PR TITLE
Push github configs into main before rc branch #2

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax
+
+# The Auro team will be the default owners for everything in the repo.
+*       @AlaskaAirlines/generalauroreviewers
+
+# Order is important. The last matching pattern has the most precedence.
+# If a pull request touches any files in the ./src dir, only these owners
+# will be requested to review.
+./src/*    @AlaskaAirlines/auroteamreviewers

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at Kevin.Sonnichsen@alaskaair.com. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,132 @@
+# Auro Design System Contributing Guidelines
+
+Please take a moment to review this document in order to make the contribution process easy and effective for everyone involved.
+
+## Feature Requests
+
+Feature requests stem from a business need. Also be sure to find out whether your idea fits with the scope and aims of the project of if this serves to address a personal/local scenario. It is up to you to make a strong case to convince the project's managers of the merits of this feature. Please provide as much detail and context as possible.
+
+## Reporting Bugs
+
+A bug is defined by: "A demonstrable problem that is caused by a file in the repository." Good bug reports are extremely helpful - thank you!
+
+Guidelines for bug reports:
+
+1. Use the search option under Boards > Work Items — check if the issue has already been reported
+1. Check if the issue has been fixed — try to reproduce it using the latest main or development branch in the repository
+1. Isolate the problem — ideally create a reduced test case and a live example
+
+A good bug report shouldn't leave others needing to chase you up for more information. Please try to be as detailed as possible in your report. What is your environment? What steps will reproduce the issue? What browser(s) and OS experience the problem? What would you expect to be the outcome? All these details will help people to fix any potential bugs.
+
+Poor bug reports will be reassigned back to the creator for revision prior to any additional investigation.
+
+## Submitting pull requests
+
+No one other than repository managers have direct access to the repository. For all pull requests you must first fork the project to your own Github account.
+
+All new work that is to be considered for merging with the `MAIN` branch must start from a new feature branch of work. This feature branch should be in response to either a bug or a new business requirement.
+
+### Feature branch naming
+
+The name of the feature branch should be descriptive as to the nature of the work and please include any references to the story or bug work item ID.
+
+### Conventional Commits
+
+This project utilizes [Conventional Commits](https://www.conventionalcommits.org/) to auto-generate release versions, based on the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#-commit-message-guidelines).
+
+```
+<type>[optional scope]: <description>
+```
+
+All commit messages must be prefixed with a specific type so that the semver release configuration can analyze the commit and apply the correct version release. Please see the following types with their respective meanings.
+
+#### MAJOR
+
+For a MAJOR release, you MUST follow this template. The use `BREAKING CHANGE:` in conjunction with any other commit type is required in order to push a major release.
+
+```
+perf(pencil): remove graphiteWidth option
+
+BREAKING CHANGE: The graphiteWidth option has been removed.
+The default graphite width of 10mm is always used for performance reasons.
+```
+
+#### MINOR
+
+```
+feat(pencil): add 'graphiteWidth' option
+```
+
+#### PATCH
+
+```
+fix(pencil): stop graphite breaking when too much pressure applied
+```
+
+#### Other commit types
+
+| type            | description                                                                                                 |
+| --------------- | ----------------------------------------------------------------------------------------------------------- |
+| build           | Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)         |
+| ci              | Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs) |
+| docs            | Documentation only changes                                                                                  |
+| feat            | A new feature (this correlates with `MINOR` in semantic versioning)                                         |
+| fix             | A bug fix (this correlates with `PATCH` in semantic versioning)                                             |
+| perf            | A code change that improves performance                                                                     |
+| BREAKING CHANGE | A code change that is not backwards compatible (correlating with `MAJOR` in semantic versioning)            |
+| refactor        | A code change that neither fixes a bug nor adds a feature                                                   |
+| style           | Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)      |
+| test            | Adding missing tests or correcting existing tests                                                           |
+
+#### Git commit messages
+
+Once you have completed your feature update, please commit all changes to the branch. All commit messages should use an **imperative mood**.
+
+Imperative mood simply means _“spoken or written as if giving a command or instruction”_. A few examples are:
+
+- Clean your room
+- Close the door
+- Take out the trash
+
+A properly formed Git commit subject line should always be able to complete the following sentence:
+
+_"If applied, this commit will (your subject line here)."_
+
+For example:
+
+- If applied, this commit will `refactor component X for accessibility`
+- If applied, this commit will `add feature Y to component X`
+
+Example messages when using Conventional Commits:
+
+```
+$ build: update to build step to include postCSS
+
+$ docs: address issue #14, typo in install instructions
+
+$ perf: restructure API to comply with new feature spec
+
+$ feat: add ability to consume large data as an array versus string
+
+$ fix: address issue #57 in regards to color output
+```
+
+### Push branch and submit pull request
+
+One you have committed new work to your feature branch, be sure to push your updates to the Github repository. Depending on your IDE or CLI configuration this may be a manual or automatic step.
+
+On the pull request page, the new pull request should be `[your-new-branch] into [main]`
+
+Please be sure to follow the **Pull Request template** that appears on the comment window.
+
+You must select up to two reviews from your team to validate that the update is correct, solves the problem presented by the story and meets all the requirements for a new merge.
+
+Finally, click the `Create` button.
+
+## Accepting and merging a pull request
+
+Once a pull request has been created, the assigned reviewers should have received notifications. Each reviewer is expected to view the pull request and review all the data per this request.
+
+A reviewer has the option to leave comments, ask questions and reject the pull request.
+
+Once two reviewers have approved the work, the pull request can then be completed.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,56 @@
+name: Bug report
+description: Create a report to help us improve
+title: "[issue summary] Please verify version before submitting new issue"
+labels:
+  - auro-cli
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: input
+    id: version
+    attributes:
+      label: Please verify the version of auro-cli you have installed
+  - type: markdown
+    attributes:
+      value: >
+        [![See it on
+        NPM!](https://img.shields.io/npm/v/@aurodesignsystem/auro-cli?style=for-the-badge&color=orange)](https://www.npmjs.com/package/@aurodesignsystem/auro-cli)
+  - type: textarea
+    id: details
+    attributes:
+      label: Please describe the bug
+      description: List out the steps to reproduce the behavior and include screenshots
+      placeholder: |
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        4. See error
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description:
+        Please add a clear and concise description of what you expected to
+        happen.
+  - type: dropdown
+    id: os
+    attributes:
+      label: What OS are you seeing the problem on?
+      multiple: true
+      options:
+        - Linux
+        - Mac
+        - Windows
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add any other context about the problem here.
+  - type: textarea
+    id: exit-criteria
+    attributes:
+      label: Exit criteria
+      description: Define your issue's exit criteria
+      placeholder: "This issue can be closed once the error has been corrected. Any additional scope e.g. updates or refactors, should be discussed PRIOR to adding scope to this issue."

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,27 @@
+name: Feature request
+description: Suggest an idea for this project
+title: "auro-cli: [feature summary]"
+labels:
+  - auro-cli
+body:
+  - type: textarea
+    id: request
+    attributes:
+      label: Is your feature request related to a problem? Please describe.
+      description: A clear and concise description of what the problem is.
+      placeholder: Ex. I'm always frustrated when [...]
+  - type: textarea
+    id: solution
+    attributes:
+      label: Describe the solution you'd like
+      description: A clear and concise description of what you want to happen.
+  - type: textarea
+    id: alternative
+    attributes:
+      label: Describe alternatives you've considered
+      description: A clear and concise description of any alternative solutions or features you've considered.
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/general-support.yml
+++ b/.github/ISSUE_TEMPLATE/general-support.yml
@@ -1,0 +1,21 @@
+name: General support
+description: Suggestions that are not related to bugs or new features
+title: "auro-cli: [issue]"
+labels:
+  - auro-cli
+body:
+  - type: textarea
+    id: request
+    attributes:
+      label: General Support Request
+      description: A clear and concise description of what you are interested in seeing.
+  - type: textarea
+    id: solution
+    attributes:
+      label: Possible Solution
+      description: Not obligatory, but suggest an idea of how to implement the requested update.
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+# Alaska Airlines Pull Request
+
+## Type of change:
+
+Please delete options that are not relevant.
+
+- [ ] New capability
+- [ ] Revision of an existing capability
+- [ ] Infrastructure change (automation, etc.)
+- [ ] Other (please elaborate)
+
+## Checklist:
+
+- [ ] My update follows the CONTRIBUTING guidelines of this project
+- [ ] I have performed a self-review of my own update
+
+**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**
+
+_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._
+
+**Thank you for your submission!**<br>
+-- Auro Design System Team

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,172 @@
+repository:
+  # See https://docs.github.com/en/free-pro-team@latest/rest/reference/repos#edit for all available settings.
+  # See https://github.com/apps/settings for app settings
+
+  # A short description of the repository that will show up on GitHub
+  description: A cli tool to support the Auro Design System
+
+  # A URL with more information about the repository
+  homepage: https://auro.alaskaair.com/auro-cli
+
+  # A comma-separated list of topics to set on the repository
+  topics: auro, design-system, cli
+
+  # Either `true` to enable issues for this repository, `false` to disable them.
+  has_issues: true
+
+  # Either `true` to enable the wiki for this repository, `false` to disable it.
+  has_wiki: false
+
+  # Either `true` to enable downloads for this repository, `false` to disable them.
+  has_downloads: true
+
+  # Updates the default branch for this repository.
+  default_branch: main
+
+  # Either `true` to enable automatic deletion of branches on merge, or `false` to disable
+  delete_branch_on_merge: true
+
+  # Either `true` to allow squash-merging pull requests, or `false` to prevent
+  # squash-merging.
+  allow_squash_merge: false
+
+  # Either `true` to allow merging pull requests with a merge commit, or `false`
+  # to prevent merging pull requests with merge commits.
+  allow_merge_commit: false
+
+  # Either `true` to allow rebase-merging pull requests, or `false` to prevent
+  # rebase-merging.
+  allow_rebase_merge: true
+
+# See https://docs.github.com/en/rest/reference/teams#add-or-update-team-repository-permissions for available options
+teams:
+  # The permission to grant the team. Can be one of:
+  # * `pull` - can pull, but not push to or administer this repository.
+  # * `push` - can pull and push, but not administer this repository.
+  # * `admin` - can pull, push and administer this repository.
+  # * `maintain` - Recommended for project managers who need to manage the repository without access to sensitive or destructive actions.
+  # * `triage` - Recommended for contributors who need to proactively manage issues and pull requests without write access.
+  - name: auro-team
+    permission: admin
+  - name: nonauroteamwriteaccess
+    permission: push
+
+branches:
+  - &default_protection
+    # https://developer.github.com/v3/repos/branches/#update-branch-protection
+    # Branch Protection settings. Set to null to disable
+    protection:
+      # Required. Require at least one approving review on a pull request, before merging. Set to null to disable.
+      required_pull_request_reviews:
+        # The number of approvals required. (1-6)
+        required_approving_review_count: 1
+        # Dismiss approved reviews automatically when a new commit is pushed.
+        dismiss_stale_reviews: true
+        # Blocks merge until code owners have reviewed.
+        require_code_owner_reviews: true
+        # Required. Require status checks to pass before merging. Set to null to disable
+        # Specify which users and teams can dismiss pull request reviews. Pass an empty dismissal_restrictions object to disable. User and team dismissal_restrictions are only available for organization-owned repositories. Omit this parameter for personal repositories.
+        dismissal_restrictions:
+          users: ["blackfalcon"]
+      # Required. Require status checks to pass before merging. Set to null to disable
+      required_status_checks:
+        # Required. Require branches to be up to date before merging.
+        strict: true
+        # Required. The list of status checks to require in order to merge into this branch
+        contexts: ["test (18.x)", "test (20.x)", "license/cla"]
+      # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
+      enforce_admins: false
+      # Required. Restrict who can push to this branch. Team and user restrictions are only available for organization-owned repositories. Set to null to disable.
+      restrictions: null
+      # Prevent merge commits from being pushed to matching branches
+      required_linear_history: true
+
+  - name: main
+    <<: *default_protection
+
+  - name: beta
+    <<: *default_protection
+
+# Labels: define labels for Issues and Pull Requests
+labels:
+  - name: auro-cli
+    description:
+    process: Key filter for this repo
+  - name: duplicate
+    description: This Issue or Pull Request already exists
+  - name: not-reviewed
+    description: Issue has not been reviewed by Auro team members
+  - name: good first issue
+    description: Good for newcomers
+    aliases:
+      - beginner-friendly
+      - beginner
+      - good-starter-issue
+      - good for beginner
+      - Good for beginners
+      - starter-issue
+      - starter
+  - name: help wanted
+    description:
+      Extra attention is needed, this user requires assistance to complete
+      the work
+  - name: released
+    description: Completed work has been released
+  - name: "Status: Work In Progress"
+    description: Issue or Pull Request work is in Progress
+  - name: "Status: Review Needed"
+    description: Work is completed, user is requesting feedback
+  - name: "Status: Complete"
+    description: Owner has completed work and considers it ready to be merged
+  - name: "Status: Blocked"
+    description: Progress on the issue is Blocked, immediate attention is required
+    aliases:
+      - blocked
+  - name: "Abandoned"
+    description: The author of this issue or Pull Request is not responding
+    aliases:
+      - wontfix
+      - invalid
+  - name: "Type: Bug"
+    description: Bug or Bug fixes
+    aliases:
+      - bug
+  - name: "Type: Feature"
+    description: New Feature
+    aliases:
+      - enhancement
+  - name: "Type: Design"
+    description: New Design
+    aliases:
+      - enhancement
+  - name: "Type: Content"
+    description: Adding or editing content
+    aliases:
+      - enhancement
+  - name: "Type: Refactoring"
+    description: A code change that neither fixes a bug nor adds a feature
+    aliases:
+      - refactor
+  - name: "Type: Documentation"
+    description: Documentation only changes
+    aliases:
+      - documents
+      - document
+  - name: "Type: CI"
+    description: Changes to CI configuration files and scripts
+    aliases:
+      - ci
+  - name: "Type: Perf"
+    description: Performance update to existing code
+  - name: "Question"
+    description: Further information is requested
+    aliases:
+      - question
+  - name: "Type: Dependencies"
+    description: Pull requests that update a dependency file
+    aliases:
+      - dependencies
+  - name: "Type: UI Update"
+    description: Changes to the user interface
+    aliases:
+      - dependencies

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,19 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 30
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+  - help-wanted
+# Label to use when marking an issue as stale
+staleLabel: wontfix
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: This issue has been automatically closed because it has not had
+  recent activity. Thank you for your contributions.

--- a/.github/workflows/addToProject.yml
+++ b/.github/workflows/addToProject.yml
@@ -1,0 +1,10 @@
+name: Add issue to Auro project
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  call-auro-assign-workflow:
+    uses: AlaskaAirlines/auro-library/.github/workflows/addToProject.yml@main
+    secrets: inherit

--- a/.github/workflows/autoAssign.yml
+++ b/.github/workflows/autoAssign.yml
@@ -1,0 +1,9 @@
+name: Issue assignment
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  call-auro-assign-workflow:
+    uses: AlaskaAirlines/auro-library/.github/workflows/autoAssign.yml@main

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,57 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: ["main"]
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["javascript"]
+        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4.1.1
+
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+
+          # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+          # queries: security-extended,security-and-quality
+
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      # - name: Autobuild
+      # uses: github/codeql-action/autobuild@v2
+
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+
+      #   If the Autobuild fails above, remove it and uncomment the following three lines.
+      #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+
+      # - run: |
+      #   echo "Run, Build Application using script"
+      #   ./location_of_script_within_repo/buildscript.sh
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/duplicate-issue.yml
+++ b/.github/workflows/duplicate-issue.yml
@@ -1,0 +1,11 @@
+name: Duplicate Issue
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: wow-actions/duplicate-issue@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/testPublish.yml
+++ b/.github/workflows/testPublish.yml
@@ -1,0 +1,44 @@
+name: Test and publish
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the main branch.
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      - run: npm run test
+
+  release:
+    # Only release on push to main
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - uses: cycjimmy/semantic-release-action@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "lint": "eslint --cache --fix && prettier . --write",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "test": "echo \"Notice: no tests available\" && exit 0"
   },
   "author": "Ryan Menner",
   "license": "ISC",


### PR DESCRIPTION
## Summary by Sourcery

Push GitHub configuration files into the main branch, including repository settings, issue templates, and workflows for CI/CD and community management.

Enhancements:
- Add a test script placeholder in package.json to indicate no tests are available.

CI:
- Introduce a CodeQL workflow for security analysis on the main branch.
- Add a test and publish workflow to automate testing and releasing on the main branch.
- Implement a duplicate issue workflow to manage issue comments.
- Add a workflow to automatically assign issues to the Auro project.
- Introduce an issue assignment workflow to handle new issues.

Documentation:
- Add a comprehensive CONTRIBUTING.md file to guide contributors on feature requests, bug reporting, and pull request submissions.
- Introduce a CODE_OF_CONDUCT.md to establish community standards and behavior expectations.