### PR TITLE
Enhance web test runner with coverage reporting and redirect for coverage URL in dev command

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest]
         node-version: [20, 22]
 
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "esbuild": "^0.25.3",
         "husky": "^9.1.7",
         "lint-staged": "^15.5.1",
+        "open": "^10.1.2",
         "semantic-release": "^24.2.3",
         "tsc-alias": "^1.8.15"
       },
@@ -5579,6 +5580,32 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@web/dev-server/node_modules/define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@web/dev-server/node_modules/open": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@web/parse5-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@web/parse5-utils/-/parse5-utils-2.1.0.tgz",
@@ -5712,6 +5739,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/@web/test-runner-core/node_modules/define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@web/test-runner-core/node_modules/globby": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
@@ -5760,6 +5796,23 @@
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@web/test-runner-core/node_modules/open": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -6366,6 +6419,22 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "license": "MIT"
+    },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -7809,6 +7878,36 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/default-browser": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
+      "integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
+      "integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/default-gateway": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-6.0.3.tgz",
@@ -7839,12 +7938,16 @@
       }
     },
     "node_modules/define-lazy-prop": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/define-properties": {
@@ -10153,6 +10256,41 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container/node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-interactive": {
@@ -15375,17 +15513,35 @@
       "integrity": "sha512-Fvw+Jemq5fjjyWz6CpKx6w9s7xxqo3+JCyM0WXWeCSOboZ8ABkyvP8ID4CZuChA/wxSx+XSJmdOm8rGVyJ1hdQ=="
     },
     "node_modules/open": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
-      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.1.2.tgz",
+      "integrity": "sha512-cxN6aIDPz6rm8hbebcP7vrQNhvRcveZoJU72Y7vskh4oIm+BZwBECnx5nTmrlres1Qapvx27Qo1Auukpf8PKXw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "define-lazy-prop": "^2.0.0",
-        "is-docker": "^2.1.1",
-        "is-wsl": "^2.2.0"
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "is-wsl": "^3.1.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open/node_modules/is-wsl": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
+      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -17885,6 +18041,19 @@
       "peerDependencies": {
         "lit": "^2 || ^3",
         "rollup": "^2 || ^3 || ^4"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
+      "integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/run-async": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "esbuild": "^0.25.3",
     "husky": "^9.1.7",
     "lint-staged": "^15.5.1",
+    "open": "^10.1.2",
     "semantic-release": "^24.2.3",
     "tsc-alias": "^1.8.15"
   }

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -11,7 +11,7 @@ export default program
   .option("-w, --watch", "Set watch number for the test")
   .description("Run the web test runner to test the component library")
   .action(async (option) => {
-    const command = `npx wtr --config ${cliRootDir}/dist/configs/web-test-runner.config.mjs`;
+    const command = `npx wtr --config ${cliRootDir}/dist/configs/web-test-runner.config.mjs --coverage`;
 
     if (option.watch) {
       shell(`${command} --watch`);

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { program } from "commander";
+import open from "open";
 import { shell } from "#utils/shell.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -9,14 +10,24 @@ const cliRootDir = path.resolve(path.dirname(__filename), "..");
 export default program
   .command("test")
   .option("-w, --watch", "Set watch number for the test")
+  .option("-c, --coverage-report", "Generate coverage report")
+  .option("-o, --open", "Open the coverage report in the browser")
   .description("Run the web test runner to test the component library")
   .action(async (option) => {
-    const command = `npx wtr --config ${cliRootDir}/dist/configs/web-test-runner.config.mjs --coverage`;
+    let command = `npx wtr --config ${cliRootDir}/dist/configs/web-test-runner.config.mjs`;
+    const coveragePath = `${process.cwd()}/coverage/index.html`;
+
+    if (option.coverageReport) {
+      command += " --coverage";
+    }
 
     if (option.watch) {
-      shell(`${command} --watch`);
-      return;
+      command += " --watch";
     }
 
     shell(command);
+
+    if (option.open) {
+      await open(coveragePath);
+    }
   });

--- a/src/configs/web-test-runner.config.mjs
+++ b/src/configs/web-test-runner.config.mjs
@@ -11,7 +11,6 @@ export default {
       functions: 80,
       lines: 80,
     },
-    reportDir: "demo/coverage",
     reporters: ["html"],
   },
   mimeTypes: {

--- a/src/configs/web-test-runner.config.mjs
+++ b/src/configs/web-test-runner.config.mjs
@@ -11,6 +11,8 @@ export default {
       functions: 80,
       lines: 80,
     },
+    reportDir: "demo/coverage",
+    reporters: ["html"],
   },
   mimeTypes: {
     "**/*.scss": "js",

--- a/src/scripts/build/devServerUtils.js
+++ b/src/scripts/build/devServerUtils.js
@@ -37,11 +37,6 @@ export async function startDevelopmentServer(options = {}) {
       // HTML file extension middleware
       middleware: [
         function rewriteIndex(context, next) {
-          if (context.url.endsWith("coverage")) {
-            context.redirect("/coverage/index.html");
-            return;
-          }
-
           if (!context.url.endsWith("/") && !context.url.includes(".")) {
             context.url += ".html";
           }

--- a/src/scripts/build/devServerUtils.js
+++ b/src/scripts/build/devServerUtils.js
@@ -1,7 +1,6 @@
 import { startDevServer } from "@web/dev-server";
 import { hmrPlugin } from "@web/dev-server-hmr";
 import ora from "ora";
-
 /**
  * Default server configuration
  */
@@ -38,6 +37,11 @@ export async function startDevelopmentServer(options = {}) {
       // HTML file extension middleware
       middleware: [
         function rewriteIndex(context, next) {
+          if (context.url.endsWith("coverage")) {
+            context.redirect("/coverage/index.html");
+            return;
+          }
+
           if (!context.url.endsWith("/") && !context.url.includes(".")) {
             context.url += ".html";
           }


### PR DESCRIPTION
# Alaska Airlines Pull Request

## Key Changes:

When `auro test` is run it now saves the coverage folder in the demo dir. I have updated the configuration of the dev command to account for `/coverage`. The process is as follows.

1. `auro test -o -c`

## Type of change:

Please delete options that are not relevant.

- [ ] New capability
- [x] Revision of an existing capability
- [ ] Infrastructure change (automation, etc.)
- [ ] Other (please elaborate)

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Enhance the web test runner by enabling coverage reporting, configuring the coverage output directory and reporter, and adding a development server redirect for the coverage URL.

Enhancements:
- Redirect "/coverage" requests in the development server to "/coverage/index.html".
- Enable the --coverage flag by default when running the web-test-runner command.
- Configure the coverage report directory as "demo/coverage" and add the HTML reporter in the web-test-runner config.