### PR TITLE
Correct config path handling in test command

### DIFF
--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -14,7 +14,13 @@ export default program
   .option("-o, --open", "Open the coverage report in the browser")
   .description("Run the web test runner to test the component library")
   .action(async (option) => {
-    let command = `npx wtr --config ${cliRootDir}/dist/configs/web-test-runner.config.mjs`;
+    const configPath = path.join(
+      cliRootDir,
+      "dist",
+      "configs",
+      "web-test-runner.config.mjs",
+    );
+    let command = `npx wtr --config "${configPath}"`;
     const coveragePath = `${process.cwd()}/coverage/index.html`;
 
     if (option.coverageReport) {


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Use path.join to correctly construct and wrap the web-test-runner config path in quotes in the test command

Bug Fixes:
- Quote the web-test-runner config path in the test command to handle spaces

Enhancements:
- Construct the config path using path.join for consistent cross-platform paths