### PR TITLE
Add remoteReadmeUrl property to ProcessorConfig and update processDocFiles to use it

### DIFF
--- a/src/scripts/build/defaultDocsBuild.js
+++ b/src/scripts/build/defaultDocsBuild.js
@@ -10,6 +10,7 @@ import {
  * @typedef {Object} ProcessorConfig
  * @property {boolean} [overwriteLocalCopies=true] - The release version tag to use instead of master.
  * @property {string} [remoteReadmeVersion="master"] - The release version tag to use instead of master.
+ * @property {string} [remoteReadmeUrl] - The release version tag to use instead of master.
  * @property {string} [remoteReadmeVariant=""] - The variant string to use for the README source.
  * (like "_esm" to make README_esm.md).
  */
@@ -40,10 +41,12 @@ export const fileConfigs = (config) => [
   {
     identifier: "README.md",
     input: {
-      remoteUrl: generateReadmeUrl(
-        config.remoteReadmeVersion,
-        config.remoteReadmeVariant,
-      ),
+      remoteUrl:
+        config.remoteReadmeUrl ||
+        generateReadmeUrl(
+          config.remoteReadmeVersion,
+          config.remoteReadmeVariant,
+        ),
       fileName: pathFromCwd("/docTemplates/README.md"),
       overwrite: config.overwriteLocalCopies,
     },
@@ -89,5 +92,9 @@ export async function processDocFiles(config = defaultDocsProcessorConfig) {
 }
 
 export async function runDefaultDocsBuild() {
-  await processDocFiles();
+  await processDocFiles({
+    ...defaultDocsProcessorConfig,
+    remoteReadmeUrl:
+      "https://raw.githubusercontent.com/AlaskaAirlines/auro-templates/main/templates/default/README.md",
+  });
 }


### PR DESCRIPTION
# Alaska Airlines Pull Request

Update the docs processor to use new remote readme url

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Enable overriding the remote README URL in the documentation processor and configure a default URL for the default docs build.

New Features:
- Introduce remoteReadmeUrl property in ProcessorConfig to specify a custom remote README URL

Enhancements:
- Modify fileConfigs in processDocFiles to use remoteReadmeUrl when provided, falling back to the generated URL
- Update runDefaultDocsBuild to include a default remoteReadmeUrl pointing to the GitHub raw README of the auro-templates repository