### PR TITLE
fix: update loadPaths to find scss paths

### DIFF
--- a/src/configs/web-test-runner.config.mjs
+++ b/src/configs/web-test-runner.config.mjs
@@ -20,7 +20,7 @@ export default {
     rollupAdapter(
       litScss({
         options: {
-          loadPaths: ["../../node_modules", "../node_modules", "node_modules"],
+          loadPaths: ["../../node_modules", "../node_modules", "node_modules", `${process.cwd()}/src/styles`, `${process.cwd()}/src`],
         },
       }),
     ),

--- a/src/scripts/analyze.js
+++ b/src/scripts/analyze.js
@@ -7,6 +7,6 @@ import { shell } from "#utils/shell.js";
  */
 export async function analyzeComponents(sourceFiles, outFile) {
   shell(
-    `npx wca analyze ${sourceFiles || "scripts/wca/*"} --outFiles ${outFile || "docs/api.md"}`,
+    `npx --package=web-component-analyzer -y -- wca analyze ${sourceFiles || "scripts/wca/*"} --outFiles ${outFile || "docs/api.md"}`,
   );
 }

--- a/src/scripts/build/configUtils.js
+++ b/src/scripts/build/configUtils.js
@@ -36,7 +36,7 @@ export function getPluginsConfig(modulePaths = [], options = {}) {
     litScss({
       minify: { fast: true },
       options: {
-        loadPaths: allModulePaths,
+        loadPaths: [...allModulePaths, `${process.cwd()}/src/styles`, `${process.cwd()}/src`],
       },
     }),
     watchGlobs(watchPatterns),


### PR DESCRIPTION
# Alaska Airlines Pull Request

- update loadPaths in web-test-runner and configUtils to include current working directory styles
- adjust wca npx command to install package if not available

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Update SCSS loadPaths to include local style directories and ensure web-component-analyzer is auto-installed when analyzing components

Enhancements:
- Extend SCSS loadPaths in web-test-runner config and configUtils to include project src/styles and src directories
- Invoke web-component-analyzer via npx with --package and -y flags in analyzeComponents script for automatic installation