### PR TITLE
fix: add optional dependency for rollup on Linux x64

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,9 @@
       },
       "engines": {
         "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-linux-x64-gnu": "*"
       }
     },
     "node_modules/@actions/github": {

--- a/package.json
+++ b/package.json
@@ -81,5 +81,8 @@
     "open": "^10.2.0",
     "plop": "^4.0.3",
     "tsc-alias": "^1.8.16"
+  },
+  "optionalDependencies": {
+    "@rollup/rollup-linux-x64-gnu": "*"
   }
 }


### PR DESCRIPTION
# Alaska Airlines Pull Request

Build on github is looking for the rollup linux dep

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Bug Fixes:
- Add @rollup/rollup-linux-x64-gnu as an optional dependency in package.json