### PR TITLE
feat: Add release notes generation option to `check-commits` command

### DIFF
--- a/src/commands/check-commits.ts
+++ b/src/commands/check-commits.ts
@@ -9,9 +9,10 @@ export default program
     "Set label on the pull request based on the commit message type",
   )
   .option("-d, --debug", "Display detailed commit information for debugging")
+  .option("-r, --release-notes", "Generate release notes based on commit messages")
   .description(
     "Check commits in the local repository for the types of semantic commit messages made and return the results.",
   )
   .action(async (option) => {
-    await analyzeCommits(option.debug, option.setLabel);
+    await analyzeCommits(option.debug, option.setLabel, option.releaseNotes);
   });

--- a/src/scripts/check-commits/commit-analyzer.ts
+++ b/src/scripts/check-commits/commit-analyzer.ts
@@ -7,6 +7,77 @@ import { displayDebugView, getColoredType } from "./display-utils.ts";
 import { applyLabelToPR, getExistingLabels } from "./github-labels.ts";
 
 /**
+ * Generate release notes in the specified format
+ * First tries to show only feat, fix, and breaking commits
+ * If none found, shows all commits for user selection
+ * @param commitList The list of commits to process
+ */
+function generateReleaseNotes(commitList: CommitInfo[]): void {
+  const releaseCommitTypes = ["feat", "fix", "breaking"];
+  
+  // Filter for preferred commit types first
+  const releaseCommits = commitList.filter(commit => 
+    releaseCommitTypes.includes(commit.type)
+  );
+  
+  // Use filtered commits if any found, otherwise use all commits
+  const commitsToShow = releaseCommits.length > 0 ? releaseCommits : commitList;
+  
+  if (commitsToShow.length === 0) {
+    console.log("No commits found to include in release notes.\n");
+    return;
+  }
+  
+  console.log("\n------\n");
+  console.log("### In this release\n");
+  
+  for (const commit of commitsToShow) {
+    // Format: - {short commit hash} {commit message}
+    console.log(`- ${commit.hash} ${commit.subject}`);
+    
+    // Add extra commit message content if body exists
+    if (commit.body?.trim()) {
+      // Split body into meaningful chunks, handling different separators
+      const bodyText = commit.body.trim();
+      
+      // Split by common separators and clean up
+      const bodyLines = bodyText
+        .split(/\n+/)  // Split on one or more newlines
+        .map(line => line.trim())
+        .filter(line => line.length > 0);
+      
+      for (const line of bodyLines) {
+        // Handle issue references and add proper spacing
+        let formattedLine = line;
+        
+        // Add spaces before issue references like AlaskaAirlines/auro-cli#108
+        formattedLine = formattedLine.replace(
+          /([^\s])(AlaskaAirlines\/[a-zA-Z0-9-]+#\d+)/g, 
+          '$1 $2'
+        );
+        
+        // Add spaces between consecutive issue references
+        formattedLine = formattedLine.replace(
+          /(AlaskaAirlines\/[a-zA-Z0-9-]+#\d+)([^\s])/g, 
+          '$1 $2'
+        );
+        
+        console.log(`  - ${formattedLine}`);
+      }
+    }
+  }
+  
+  console.log("\n------\n");
+  
+  // Show helpful info about what was included
+  if (releaseCommits.length > 0) {
+    console.log(chalk.green(`✓ Showing ${releaseCommits.length} commits of types: ${releaseCommitTypes.join(", ")}`));
+  } else {
+    console.log(chalk.yellow(`⚠ No feat/fix/breaking commits found. Showing all ${commitList.length} commits for your selection.`));
+  }
+}
+
+/**
  * Analyze commit messages in the repository
  * @param debug Whether to display detailed debug information
  * @param verbose Whether to display verbose commit messages without truncation
@@ -16,11 +87,19 @@ import { applyLabelToPR, getExistingLabels } from "./github-labels.ts";
 export async function analyzeCommits(
   debug = false,
   setLabel = false,
+  releaseNotes = false,
 ): Promise<void> {
   const spinner = ora("Checking commits...\n").start();
 
   try {
     const commitList = await Git.getCommitMessages();
+
+    // Generate release notes if requested
+    if (releaseNotes) {
+      spinner.succeed(`Total commits analyzed: ${commitList.length}`);
+      generateReleaseNotes(commitList);
+      return;
+    }
 
     // Only display commit details if debug mode is enabled
     if (debug) {


### PR DESCRIPTION
# Alaska Airlines Pull Request

Created a pre-formatted output of the check-commits command to copy paste into RC notes

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

New Features:
- Add a `--release-notes` option to the check-commits command to output pre-formatted release notes