### PR TITLE
feat: remove the need for wca abstraction function

### DIFF
--- a/.github/workflows/pr-release.yml
+++ b/.github/workflows/pr-release.yml
@@ -25,6 +25,9 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - name: Install dependencies
         run: npm clean-install
+
+      - name: Upgrade npm
+        run: npm install -g npm@latest
       - name: Build
         run: npm run build
       - name: Test
@@ -32,7 +35,7 @@ jobs:
       - name: Generate PR release version
         run: npm run auro-internal -- pr-release -p ${{ github.event.pull_request.number }}
       - name: Publish to NPM
-        run: npm publish --registry=https://registry.npmjs.org
+        run: npm publish --registry=https://registry.npmjs.org --tag=latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -54,6 +54,9 @@ jobs:
           node-version: 22
       - name: Install dependencies
         run: npm clean-install
+      
+      - name: Upgrade npm
+        run: npm install -g npm@latest
       - name: Verify the integrity of provenance attestations and registry signatures for installed dependencies
         run: npm audit signatures
       - name: Build

--- a/src/scripts/docs/docs-generator.ts
+++ b/src/scripts/docs/docs-generator.ts
@@ -72,13 +72,17 @@ export default class Docs {
    * Extract custom elements from the manifest
    */
   static getElements(): CustomElementDeclaration[] {
+
+    // if wca exists, use only wca modules
+    const wcaModules = Docs.manifest.modules.filter(Docs.isWcaModule);
+
     return Docs.manifest.modules.reduce(
       (els: CustomElementDeclaration[], module: Module) =>
         els.concat(
           module.declarations?.filter(
             (dec: Declaration): dec is CustomElementDeclaration => 
               'customElement' in dec && dec.customElement === true && 'tagName' in dec && 
-              Docs.isWcaModule(module),
+              (wcaModules.length > 0 ? Docs.isWcaModule(module) : true),
           ) ?? [],
         ),
       [],


### PR DESCRIPTION
# Alaska Airlines Pull Request

Enables removing the dependency on the wca class when using the `@customElement` jsdoc tag like below. Auro-cli will still work if the jsdoc is not updated and the existing wca code is present.
```
/**
 * The auro-tokenavatar element provides users a way to illustrate design token colors and their related data for text, border, alert, interactive or icon uses.
 * @customElement auro-tokenavatar
 * @attr {Boolean} ondark - DEPRECATED - use `appearance` instead.
 */
 ```
 

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Enable the documentation generator to work without requiring WCA modules by conditionally filtering modules based on the presence of WCA declarations.

Enhancements:
- Detect WCA modules in the manifest and store them separately
- Adjust the element filtering logic to only restrict to WCA modules when they exist, otherwise include all modules