### PR TITLE
fix: correct glob pattern in custom elements manifest configuration #232

### DIFF
--- a/src/configs/custom-elements-manifest.config.mjs
+++ b/src/configs/custom-elements-manifest.config.mjs
@@ -1,7 +1,7 @@
 import { cemSorterPlugin } from "@wc-toolkit/cem-sorter";
 
 export default {
-  globs: ["src/*.*js", "scripts/wca/**/*.*js"],
+  globs: ["src/**/*.*js", "scripts/wca/**/*.*js"],
   litelement: true,
   packagejson: true,
   dependencies: true,


### PR DESCRIPTION
# Alaska Airlines Pull Request

- #232 

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Bug Fixes:
- Correct glob pattern from "src/*.*js" to "src/**/*.*js" in custom-elements-manifest.config.mjs to match all JS files recursively under src.