### PR TITLE
fix: improve dev mode dist build and add class exports to dts

### DIFF
--- a/src/configs/custom-elements-manifest.config.mjs
+++ b/src/configs/custom-elements-manifest.config.mjs
@@ -1,5 +1,51 @@
 import { cemSorterPlugin } from "@wc-toolkit/cem-sorter";
 import { jsxTypesPlugin } from "@wc-toolkit/jsx-types";
+import fs from "fs/promises";
+
+function addDtsExportsPlugin() {
+  return {
+    // Make sure to always give your plugin a name! This helps when debugging
+    name: 'add-dts-exports-plugin',
+    packageLinkPhase({customElementsManifest}){
+
+      // find modules where path matches 'src/index.js'
+      const exportedModules = customElementsManifest.modules.filter(
+        (mod) => mod.path.endsWith("src/index.js")
+      );
+
+      const exportNames = [];
+
+      // collect all export names
+      exportedModules[0].exports.forEach((exp) => {
+        exportNames.push(exp.name);
+      });
+
+      if (exportNames.length === 0) {
+        console.warn(
+          "No exports found for 'src/index.js'. Skipping export statement addition."
+        );
+        return;
+      }
+
+      // construct export statement
+      const exportStatement = `declare global {
+  namespace svelteHTML {
+    interface IntrinsicElements extends CustomElements {}
+  } 
+}\n
+
+export { ${exportNames.join(', ')} } from "./index.js";\n`;
+
+      // append export statement to dist/index.d.ts
+      fs.appendFile('dist/index.d.ts', exportStatement).then(() => {
+        console.info('Appended export statements to index.d.ts');
+      }).catch((err) => {
+        console.error(`Error appending to index.d.ts: ${err.message}`);
+      });
+
+    },
+  }
+}
 
 export default {
   globs: ["src/**/*.*js", "scripts/wca/**/*.*js"],
@@ -14,8 +60,8 @@ export default {
     jsxTypesPlugin({
       fileName: "index.d.ts",
       outdir: "dist",
-      defaultExport: true,
-      excludeCssCustomProperties: true,
-    })
+      excludeCssCustomProperties: true
+    }),
+    addDtsExportsPlugin(),
   ],
 };

--- a/src/scripts/build/index.js
+++ b/src/scripts/build/index.js
@@ -25,7 +25,9 @@ async function runProductionBuild(options) {
   const demoConfig = getDemoConfig(options);
 
   // Add terser for minification in production
-  mainBundleConfig.config.plugins.push(terser());
+  if (!options.dev) {
+    mainBundleConfig.config.plugins.push(terser());
+  }
 
   // Generate docs if enabled
   await generateDocs(options);


### PR DESCRIPTION
# Alaska Airlines Pull Request

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Improve the dev build output configuration and ensure TypeScript declaration files re-export public classes from the main entry point.

New Features:
- Append export statements for all src/index.js exports to dist/index.d.ts via a custom custom-elements-manifest plugin.

Enhancements:
- Add a dev mode option to build configs to disable CSS minification and use stable, non-hashed filenames for easier debugging.
- Adjust demo and main bundle asset naming to use hashed filenames in production while keeping core entry files stable.
- Skip JavaScript minification with terser when running builds in dev mode.