### PR TITLE
fix: correct return type property name in methods table rendering

### DIFF
--- a/src/scripts/docs/docs-generator.ts
+++ b/src/scripts/docs/docs-generator.ts
@@ -146,7 +146,7 @@ export default class Docs {
         .map((m: ClassMember) => ({
           ...m,
           parameters: renderParameters('parameters' in m ? m.parameters as Parameter[] : undefined),
-          returnType: 'return' in m && m.return ? getType(m.return) : "",
+          return: 'return' in m && m.return ? getType(m.return) : "",
         })),
     );
     if (methodsTable) {


### PR DESCRIPTION
# Alaska Airlines Pull Request

Fixed issue where the method return type was displaying `[object Object]` instead of the value like `void`

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Bug Fixes:
- Correct method table rendering to use the proper return type property so values like 'void' display instead of '[object Object]'.