### PR TITLE
feat: add template option to sync command

### DIFF
--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -8,6 +8,7 @@ import { syncDotGithubDir } from "#scripts/syncDotGithubDir.js";
 export default program
   .command("sync")
   .option("-r, --ref <branch/tag/commit>", "Git reference (branch/tag/commit) to use", "main")
+  .option("-t, --template <name>", "Template based on which to sync", "default")
   .description(
     "Script runner to synchronize local repository configuration files",
   )
@@ -20,7 +21,7 @@ export default program
 
     const cwd = process.cwd();
 
-    await syncDotGithubDir(cwd, options.ref);
+    await syncDotGithubDir(cwd, options.ref, options.template);
 
     // Cleanup for specific files
     // ------------------------------------------------------

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -21,25 +21,35 @@ export default program
 
     const cwd = process.cwd();
 
-    await syncDotGithubDir(cwd, options.ref, options.template);
+    try {
+      await syncDotGithubDir(cwd, options.ref, options.template);
 
-    // Cleanup for specific files
-    // ------------------------------------------------------
+      // Cleanup for specific files
+      // ------------------------------------------------------
 
-    // Some files have specific cleanup tasks that need to be run after syncing
+      // Some files have specific cleanup tasks that need to be run after syncing
 
-    // CODEOWNERS - has a bizarre issue with line endings. This is a workaround!
-    // Maybe it has to do with the file type since there's no ending?
-    const codeownersPath = `${cwd}/.github/CODEOWNERS`;
-    const codeowners = await readFile(codeownersPath, { encoding: "utf-8" });
+      try {
+        // CODEOWNERS - has a bizarre issue with line endings. This is a workaround!
+        // Maybe it has to do with the file type since there's no ending?
+        const codeownersPath = `${cwd}/.github/CODEOWNERS`;
+        const codeowners = await readFile(codeownersPath, { encoding: "utf-8" });
 
-    // Convert line endings to \n
-    const codeownersFixed = codeowners
-      .replace(/\r\n/gu, "\n")
-      .replace(/\n\n/gu, "\n");
-    await writeFile(codeownersPath, codeownersFixed, { encoding: "utf-8" });
+        // Convert line endings to \n
+        const codeownersFixed = codeowners
+          .replace(/\r\n/gu, "\n")
+          .replace(/\n\n/gu, "\n");
+        await writeFile(codeownersPath, codeownersFixed, { encoding: "utf-8" });
 
-    if (codeownersFixed.includes("\r") || codeownersFixed.includes("\n\n")) {
-      Logger.error("CODEOWNERS file still has Windows line endings.");
+        if (codeownersFixed.includes("\r") || codeownersFixed.includes("\n\n")) {
+          Logger.error("CODEOWNERS file still has Windows line endings.");
+        }
+      } catch (codeownersError) {
+        Logger.error(`Error processing CODEOWNERS file: ${codeownersError.message}`);
+        throw codeownersError;
+      }
+    } catch (error) {
+      Logger.error(`Sync operation failed: ${error.message}`);
+      process.exit(1);
     }
   });

--- a/src/scripts/syncDotGithubDir.ts
+++ b/src/scripts/syncDotGithubDir.ts
@@ -37,28 +37,38 @@ interface FileProcessorConfig {
  */
 async function getFolderItemsFromRelativeRepoPath(path: string, ref: string) {
   const octokit = new Octokit({
-    auth: process.env.GITHUB_TOKEN || '',
+    auth: process.env.GITHUB_TOKEN || ''
   });
 
-  const response = await octokit.request('GET /repos/{owner}/{repo}/contents/{path}', {
-    ref,
-    owner: 'AlaskaAirlines',
-    repo: 'auro-templates',
-    path: path,
-    headers: {
-      'X-GitHub-Api-Version': '2022-11-28'
+  try {
+    const response = await octokit.request('GET /repos/{owner}/{repo}/contents/{path}', {
+      ref,
+      owner: 'AlaskaAirlines',
+      repo: 'auro-templates',
+      path: path,
+      headers: {
+        'X-GitHub-Api-Version': '2022-11-28'
+      }
+    });
+
+    const responseData = response.data;
+    if (typeof responseData !== 'object' || !Array.isArray(responseData)) {
+      const errorMessage = `Unexpected response format: ${JSON.stringify(responseData)}`;
+      const errorSpinner = ora().start();
+      errorSpinner.fail(errorMessage);
+      throw new Error("Failed to retrieve folder items");
     }
-  });
 
-  const responseData = response.data;
-  if (typeof responseData !== 'object' || !Array.isArray(responseData)) {
-    const errorMessage = `Unexpected response format: ${JSON.stringify(responseData)}`;
+    return responseData;
+  } catch (error: any) {
     const errorSpinner = ora().start();
-    errorSpinner.fail(errorMessage);
-    throw new Error("Failed to retrieve folder items");
+    if (error.status === 404) {
+      errorSpinner.fail(`Template '${path.split('/')[1]}' not found`);
+    } else {
+      errorSpinner.fail(`Error accessing template: ${error.message}`);
+    }
+    throw error;
   }
-
-  return responseData;
 }
 
 interface ProcessIntoFileConfigArgs {
@@ -189,21 +199,7 @@ export async function syncDotGithubDir(rootDir: string, ref = 'main', template =
   if (!rootDir) {
     const errorSpinner = ora().start();
     errorSpinner.fail("Root directory must be specified");
-    // eslint-disable-next-line no-undef
-    process.exit(1);
-  }
-
-  // Remove .github directory if it exists
-  const githubPath = ".github";
-
-  const removeSpinner = ora("Removing existing .github directory...").start();
-  try {
-    await removeDirectory(githubPath);
-    removeSpinner.succeed(".github directory removed successfully");
-  } catch (error: any) {
-    removeSpinner.fail(`Error removing .github directory: ${error.message}`);
-    // eslint-disable-next-line no-undef
-    process.exit(1);
+    throw new Error("Root directory must be specified");
   }
 
   // Setup
@@ -212,11 +208,25 @@ export async function syncDotGithubDir(rootDir: string, ref = 'main', template =
   if (!process.env.GITHUB_TOKEN) {
     const tokenErrorSpinner = ora().start();
     tokenErrorSpinner.fail("GITHUB_TOKEN environment variable is not set.");
-    process.exit(1);
+    throw new Error("GITHUB_TOKEN environment variable is not set");
   }
 
   const templatesDefaultGithubPath = `templates/${template}/.github`;
+  
+  // Validate template exists BEFORE removing anything
   const folderItems = await getFolderItemsFromRelativeRepoPath(templatesDefaultGithubPath, ref);
+
+  // Only remove .github directory after successful template validation
+  const githubPath = ".github";
+  const removeSpinner = ora("Removing existing .github directory...").start();
+  try {
+    await removeDirectory(githubPath);
+    removeSpinner.succeed(".github directory removed successfully");
+  } catch (error: any) {
+    removeSpinner.fail(`Error removing .github directory: ${error.message}`);
+    throw new Error(`Failed to remove .github directory: ${error.message}`);
+  }
+
   const fileConfigs = await processFolderItemsIntoFileConfigs({
     folderItems,
     templatePathToReplace: templatesDefaultGithubPath,
@@ -246,7 +256,6 @@ export async function syncDotGithubDir(rootDir: string, ref = 'main', template =
 
   } catch (error: any) {
     processSpinner.fail(`Error processing files: ${error.message}`);
-    // eslint-disable-next-line no-undef
-    process.exit(1);
+    throw new Error(`Failed to process files: ${error.message}`);
   }
 }

--- a/src/scripts/syncDotGithubDir.ts
+++ b/src/scripts/syncDotGithubDir.ts
@@ -181,9 +181,11 @@ async function generateDirectoryTree(dirPath: string, prefix: string = '', isLas
 /**
  * Sync the .github directory with the remote repository.
  * @param {string} rootDir - The root directory of the local repository.
+ * @param {string} ref - The Git reference (branch/tag/commit) to use.
+ * @param {string} template - The template based on which to sync.
  * @returns {Promise<void>} A promise that resolves when syncing is complete.
  */
-export async function syncDotGithubDir(rootDir: string, ref = 'main') {
+export async function syncDotGithubDir(rootDir: string, ref = 'main', template = 'default') {
   if (!rootDir) {
     const errorSpinner = ora().start();
     errorSpinner.fail("Root directory must be specified");
@@ -213,7 +215,7 @@ export async function syncDotGithubDir(rootDir: string, ref = 'main') {
     process.exit(1);
   }
 
-  const templatesDefaultGithubPath = 'templates/default/.github';
+  const templatesDefaultGithubPath = `templates/${template}/.github`;
   const folderItems = await getFolderItemsFromRelativeRepoPath(templatesDefaultGithubPath, ref);
   const fileConfigs = await processFolderItemsIntoFileConfigs({
     folderItems,


### PR DESCRIPTION
# Alaska Airlines Pull Request

Added a `--template` (`-t`) option to the `sync` command, allowing users to specify which template to use for synchronization.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Add support for selecting a template when syncing the .github directory and improve error handling around sync failures.

New Features:
- Introduce a --template (-t) option to the sync command to choose which template to use when synchronizing .github files.

Bug Fixes:
- Prevent deletion of the existing .github directory when the specified template cannot be found or accessed.
- Ensure sync failures and missing configuration are surfaced as thrown errors instead of exiting the process abruptly.

Enhancements:
- Improve GitHub API response validation and error messaging when accessing template contents.
- Wrap sync and post-sync CODEOWNERS cleanup in structured error handling with clearer logging of failures.