### PR TITLE
feat: add option to skip README.md processing in docs generation

### DIFF
--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -7,6 +7,7 @@ let docsCommand = program
   .description("Generate API documentation")
   .option("-c, --cem", "Generate Custom Elements Manifest (CEM) file", false)
   .option("-a, --api", "Creates api md file from CEM", false)
+  .option("--skip-readme", "Skip README.md processing", false)
   
   docsCommand = withServerOptions(docsCommand);
 
@@ -20,7 +21,7 @@ let docsCommand = program
       await api();
     }
 
-    await docs();
+    await docs(options);
 
     if( options.serve ) {
         await serve(options);

--- a/src/scripts/build/defaultDocsBuild.js
+++ b/src/scripts/build/defaultDocsBuild.js
@@ -34,27 +34,30 @@ function pathFromCwd(pathLike) {
 
 /**
  * @param {ProcessorConfig} config - The configuration for this processor.
+ * @param {boolean} [skipReadme=false] - Whether to skip README.md processing.
  * @returns {import('../utils/sharedFileProcessorUtils').FileProcessorConfig[]}
  */
-export async function fileConfigs(config) {
+export async function fileConfigs(config, skipReadme = false) {
   const configs = [];
 
   // ---------- README.md ----------
   // Don't need to check for existence of README.md since it's always created
-  configs.push({
-    identifier: "README.md",
-    input: {
-      remoteUrl:
-        config.remoteReadmeUrl ||
-        generateReadmeUrl(
-          config.remoteReadmeVersion,
-          config.remoteReadmeVariant,
-        ),
-      fileName: pathFromCwd("/docTemplates/README.md"),
-      overwrite: config.overwriteLocalCopies,
-    },
-    output: pathFromCwd("/README.md"),
-  });
+  if (!skipReadme) {
+    configs.push({
+      identifier: "README.md",
+      input: {
+        remoteUrl:
+          config.remoteReadmeUrl ||
+          generateReadmeUrl(
+            config.remoteReadmeVersion,
+            config.remoteReadmeVariant,
+          ),
+        fileName: pathFromCwd("/docTemplates/README.md"),
+        overwrite: config.overwriteLocalCopies,
+      },
+      output: pathFromCwd("/README.md"),
+    });
+  }
 
   // ---------- index.md ----------
   if (fileExists("/docs/partials/index.md")) {
@@ -101,13 +104,14 @@ export async function fileConfigs(config) {
 /**
  *
  * @param {ProcessorConfig} config - The configuration for this processor.
+ * @param {boolean} [skipReadme=false] - Whether to skip README.md processing.
  * @return {Promise<void>}
  */
-export async function processDocFiles(config = defaultDocsProcessorConfig) {
+export async function processDocFiles(config = defaultDocsProcessorConfig, skipReadme = false) {
   // setup
   await templateFiller.extractNames();
 
-  const fileConfigsList = await fileConfigs(config);
+  const fileConfigsList = await fileConfigs(config, skipReadme);
 
   for (const fileConfig of fileConfigsList) {
     try {
@@ -119,12 +123,12 @@ export async function processDocFiles(config = defaultDocsProcessorConfig) {
   }
 }
 
-export async function runDefaultDocsBuild() {
+export async function runDefaultDocsBuild(options = {}) {
   await processDocFiles({
     ...defaultDocsProcessorConfig,
     remoteReadmeUrl:
       "https://raw.githubusercontent.com/AlaskaAirlines/auro-templates/main/templates/default/README.md",
-  });
+  }, options.skipReadme);
 }
 
 /**

--- a/src/scripts/docs/index.ts
+++ b/src/scripts/docs/index.ts
@@ -34,11 +34,11 @@ export async function api() {
   }
 }
 
-export async function docs() {
+export async function docs(options = {}) {
   const docsSpinner = ora("Compiling documentation...").start();
 
   try {
-    await runDefaultDocsBuild();
+    await runDefaultDocsBuild(options);
     docsSpinner.succeed("Documentation compiled successfully!");
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
# Alaska Airlines Pull Request

This pull request introduces an option to skip processing the `README.md` file during documentation generation. It updates the documentation build pipeline to support this new option and ensures it is properly passed through the command-line interface and internal build functions.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
