### PR TITLE
fix: handle branch name retrieval in GitHub Actions context

### DIFF
--- a/src/utils/gitUtils.ts
+++ b/src/utils/gitUtils.ts
@@ -46,8 +46,15 @@ export class Git {
       // Use the provided branch parameter, or fall back to current branch if not specified
       let branch = sourceBranch;
       if (!branch) {
-        const currentBranch = await git.branchLocal();
-        branch = currentBranch.current;
+        // In GitHub Actions PR context, GITHUB_HEAD_REF contains the actual PR branch name.
+        // branchLocal().current returns "pull/<n>/merge" in detached HEAD state, which is
+        // not a valid remote-tracking ref (it maps to refs/remotes/pull/<n>/merge, not origin/).
+        if (process.env.GITHUB_ACTIONS && process.env.GITHUB_HEAD_REF) {
+          branch = process.env.GITHUB_HEAD_REF;
+        } else {
+          const currentBranch = await git.branchLocal();
+          branch = currentBranch.current;
+        }
       }
 
       // ---- Get target branch (main) and PR commits ----


### PR DESCRIPTION
# Alaska Airlines Pull Request

This pull request updates the logic for determining the current Git branch in `gitUtils.ts`, specifically to improve compatibility with GitHub Actions. The change ensures that, when running in a GitHub Actions pull request context, the correct branch name is used instead of the detached HEAD reference.

Branch detection improvements for CI:

* Updated the logic in the `Git` class to use the `GITHUB_HEAD_REF` environment variable when running in GitHub Actions, ensuring the correct PR branch name is used instead of the detached HEAD state, which avoids issues with invalid remote-tracking refs.

## Checklist:

- [ ] My update follows the CONTRIBUTING guidelines of this project
- [ ] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Enhancements:
- Use the GITHUB_HEAD_REF environment variable in GitHub Actions PR contexts to obtain the actual source branch name instead of relying on detached HEAD metadata.