### PR TITLE
feat(cem): add auro cem command to aggregate component manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,25 @@ Write the context to a file for your AI tool:
 ```
 auro context --output AURO_CONTEXT.md
 ```
+
+`auro cem`
+Aggregates the Custom Elements Manifests (`custom-elements.json`) of every published Auro component into a single file. Components that do not publish a manifest are skipped with a warning. Useful for feeding a complete, machine-readable component API index to IDEs, docs tooling, and AI assistants.
+
+#### Options
+
+- `-o, --output <file>` Path to write the aggregated manifest (default: `custom-elements.aggregate.json`).
+- `--aggregate` Fetch and merge every component manifest (default behavior).
+
+#### Examples
+
+Generate the aggregated manifest:
+
+```
+auro cem
+```
+
+Write it to a specific path:
+
+```
+auro cem --output dist/custom-elements.aggregate.json
+```

--- a/README.md
+++ b/README.md
@@ -58,3 +58,24 @@ Open the server to a specific directory:
 ```
 auro dev --open src/
 ```
+
+`auro context`
+Prints an AI-ready context document describing the Auro Design System, its components, and usage patterns. Designed to be piped into or pasted into AI coding assistants (Claude, Cursor, Copilot, etc.) to prime them on Auro.
+
+#### Options
+
+- `-o, --output <file>` Write the context document to a file instead of stdout (e.g. `AURO_CONTEXT.md`).
+
+#### Examples
+
+Print the context to the terminal:
+
+```
+auro context
+```
+
+Write the context to a file for your AI tool:
+
+```
+auro context --output AURO_CONTEXT.md
+```

--- a/README.md
+++ b/README.md
@@ -81,12 +81,11 @@ auro context --output AURO_CONTEXT.md
 ```
 
 `auro cem`
-Aggregates the Custom Elements Manifests (`custom-elements.json`) of every published Auro component into a single file. Components that do not publish a manifest are skipped with a warning. Useful for feeding a complete, machine-readable component API index to IDEs, docs tooling, and AI assistants.
+Aggregates the Custom Elements Manifests (`custom-elements.json`) of every published Auro component into a single file. Each component's manifest is fetched from the latest published version on unpkg; components that do not publish a manifest yet are skipped. Useful for feeding a complete, machine-readable component API index to IDEs, docs tooling, and AI assistants.
 
 #### Options
 
 - `-o, --output <file>` Path to write the aggregated manifest (default: `custom-elements.aggregate.json`).
-- `--aggregate` Fetch and merge every component manifest (default behavior).
 
 #### Examples
 

--- a/build-scripts/build-config.js
+++ b/build-scripts/build-config.js
@@ -46,6 +46,7 @@ export const aliases = {
   "#configs": resolve(projectRoot, "src/configs"),
   "#commands": resolve(projectRoot, "src/commands"),
   "#scripts": resolve(projectRoot, "src/scripts"),
+  "#static": resolve(projectRoot, "src/static"),
   "#utils": resolve(projectRoot, "src/utils"),
 };
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "#configs/*": "./src/configs/*",
     "#commands/*": "./src/commands/*",
     "#scripts/*": "./src/scripts/*",
+    "#static/*": "./src/static/*",
     "#utils/*": "./src/utils/*"
   },
   "publishConfig": {

--- a/src/commands/cem.ts
+++ b/src/commands/cem.ts
@@ -19,6 +19,15 @@ interface Manifest {
   [key: string]: unknown;
 }
 
+interface FetchOutcome {
+  pkg: string;
+  manifest: Manifest | null;
+  /** Human-readable reason the manifest was skipped. */
+  reason?: string;
+  /** True when the skip was caused by a transient error (network/5xx), not a genuine 404. */
+  transient?: boolean;
+}
+
 interface ManifestSource {
   pkg: string;
   manifest: Manifest;
@@ -26,9 +35,10 @@ interface ManifestSource {
 
 /**
  * Fetch a single package's Custom Elements Manifest from unpkg.
- * Returns the parsed manifest, or null if the package does not publish one.
+ * Never throws — failures are returned as an outcome so the caller can
+ * distinguish a genuine absence (404) from a transient error.
  */
-async function fetchManifest(pkg: string): Promise<Manifest | null> {
+async function fetchManifest(pkg: string): Promise<FetchOutcome> {
   const url = `${UNPKG_BASE}/${pkg}/custom-elements.json`;
 
   let response: Response;
@@ -36,45 +46,80 @@ async function fetchManifest(pkg: string): Promise<Manifest | null> {
     response = await fetch(url);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    Logger.warn(`Skipping ${pkg}: request failed (${message})`);
-    return null;
+    return { pkg, manifest: null, reason: `request failed (${message})`, transient: true };
+  }
+
+  if (response.status === 404) {
+    return { pkg, manifest: null, reason: "no custom-elements.json published" };
   }
 
   if (!response.ok) {
-    Logger.warn(
-      `Skipping ${pkg}: no custom-elements.json (HTTP ${response.status})`,
-    );
-    return null;
+    return { pkg, manifest: null, reason: `HTTP ${response.status}`, transient: true };
   }
 
   try {
-    return (await response.json()) as Manifest;
-  } catch (_error) {
-    Logger.warn(`Skipping ${pkg}: custom-elements.json is not valid JSON`);
-    return null;
+    return { pkg, manifest: (await response.json()) as Manifest };
+  } catch {
+    return { pkg, manifest: null, reason: "custom-elements.json is not valid JSON", transient: true };
   }
 }
 
 /**
+ * Recursively namespace every local module reference in a CEM node with the
+ * owning package. A reference is local only when it has a `module` string and
+ * no `package` sibling (a `package` means it points at an external package, so
+ * its `module` must be left untouched). This keeps the merged manifest's
+ * internal references (exports' `declaration.module`, `references[].module`,
+ * etc.) pointing at the same paths as their now-namespaced modules.
+ */
+function namespaceReferences(node: unknown, pkg: string): unknown {
+  if (Array.isArray(node)) {
+    return node.map((item) => namespaceReferences(item, pkg));
+  }
+
+  if (node && typeof node === "object") {
+    const source = node as Record<string, unknown>;
+    const result: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(source)) {
+      if (key === "module" && typeof value === "string" && source.package == null) {
+        result[key] = `${pkg}/${value}`;
+      } else {
+        result[key] = namespaceReferences(value, pkg);
+      }
+    }
+    return result;
+  }
+
+  return node;
+}
+
+/**
  * Merge per-package manifests into a single Custom Elements Manifest.
- * Each source module's path is namespaced with its package so paths stay
- * unique and consumers can trace a declaration back to its component.
+ * Every module (and its internal references) is namespaced with its package so
+ * paths stay unique and every declaration remains traceable to its component.
  */
 function mergeManifests(sources: ManifestSource[]): Manifest {
   const modules: CemModule[] = [];
 
   for (const { pkg, manifest } of sources) {
     for (const module of manifest.modules ?? []) {
-      modules.push({
-        ...module,
-        path: `${pkg}/${module.path}`,
-      });
+      const namespaced = namespaceReferences(module, pkg) as CemModule;
+      namespaced.path = `${pkg}/${module.path}`;
+      modules.push(namespaced);
     }
+  }
+
+  const schemaVersions = new Set(
+    sources.map((source) => source.manifest.schemaVersion).filter(Boolean),
+  );
+  if (schemaVersions.size > 1) {
+    Logger.warn(
+      `Merging mixed CEM schema versions: ${[...schemaVersions].join(", ")}`,
+    );
   }
 
   return {
     schemaVersion: sources[0]?.manifest.schemaVersion ?? "1.0.0",
-    readme: "",
     modules,
   };
 }
@@ -82,9 +127,8 @@ function mergeManifests(sources: ManifestSource[]): Manifest {
 export default program
   .command("cem")
   .description(
-    "Aggregate the Custom Elements Manifests of all published Auro components into a single file",
+    "Fetch every published Auro component's custom-elements.json and merge them into a single aggregated manifest",
   )
-  .option("--aggregate", "Fetch and merge every component manifest", true)
   .option(
     "-o, --output <file>",
     "Path to write the aggregated manifest",
@@ -95,20 +139,14 @@ export default program
       `Fetching manifests for ${AURO_COMPONENT_PACKAGES.length} components...`,
     ).start();
 
-    const results = await Promise.allSettled(
-      AURO_COMPONENT_PACKAGES.map(async (pkg) => ({
-        pkg,
-        manifest: await fetchManifest(pkg),
-      })),
+    const outcomes = await Promise.all(
+      AURO_COMPONENT_PACKAGES.map((pkg) => fetchManifest(pkg)),
     );
 
     const sources: ManifestSource[] = [];
-    for (const result of results) {
-      if (result.status === "fulfilled" && result.value.manifest) {
-        sources.push({
-          pkg: result.value.pkg,
-          manifest: result.value.manifest,
-        });
+    for (const outcome of outcomes) {
+      if (outcome.manifest) {
+        sources.push({ pkg: outcome.pkg, manifest: outcome.manifest });
       }
     }
 
@@ -136,4 +174,21 @@ export default program
     spinner.succeed(
       `Aggregated ${sources.length}/${AURO_COMPONENT_PACKAGES.length} component manifests (${aggregate.modules?.length ?? 0} modules) to ${options.output}`,
     );
+
+    // Report skips after the spinner so output isn't garbled. Genuine 404s are
+    // expected (not every component publishes a CEM yet); transient failures
+    // mean the aggregate is incomplete and are treated as an error.
+    const skipped = outcomes.filter((outcome) => !outcome.manifest);
+    const transientFailures = skipped.filter((outcome) => outcome.transient);
+
+    for (const outcome of skipped) {
+      Logger.info(`Skipped ${outcome.pkg}: ${outcome.reason}`);
+    }
+
+    if (transientFailures.length > 0) {
+      Logger.error(
+        `${transientFailures.length} component(s) failed to fetch transiently; the aggregate may be incomplete. Re-run to retry.`,
+      );
+      process.exit(1);
+    }
   });

--- a/src/commands/cem.ts
+++ b/src/commands/cem.ts
@@ -1,0 +1,139 @@
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { Logger } from "@aurodesignsystem/auro-library/scripts/utils/logger.mjs";
+import { program } from "commander";
+import ora from "ora";
+import { AURO_COMPONENT_PACKAGES } from "#static/auroComponents.js";
+
+const UNPKG_BASE = "https://unpkg.com";
+
+interface CemModule {
+  path: string;
+  [key: string]: unknown;
+}
+
+interface Manifest {
+  schemaVersion?: string;
+  modules?: CemModule[];
+  [key: string]: unknown;
+}
+
+interface ManifestSource {
+  pkg: string;
+  manifest: Manifest;
+}
+
+/**
+ * Fetch a single package's Custom Elements Manifest from unpkg.
+ * Returns the parsed manifest, or null if the package does not publish one.
+ */
+async function fetchManifest(pkg: string): Promise<Manifest | null> {
+  const url = `${UNPKG_BASE}/${pkg}/custom-elements.json`;
+
+  let response: Response;
+  try {
+    response = await fetch(url);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    Logger.warn(`Skipping ${pkg}: request failed (${message})`);
+    return null;
+  }
+
+  if (!response.ok) {
+    Logger.warn(
+      `Skipping ${pkg}: no custom-elements.json (HTTP ${response.status})`,
+    );
+    return null;
+  }
+
+  try {
+    return (await response.json()) as Manifest;
+  } catch (_error) {
+    Logger.warn(`Skipping ${pkg}: custom-elements.json is not valid JSON`);
+    return null;
+  }
+}
+
+/**
+ * Merge per-package manifests into a single Custom Elements Manifest.
+ * Each source module's path is namespaced with its package so paths stay
+ * unique and consumers can trace a declaration back to its component.
+ */
+function mergeManifests(sources: ManifestSource[]): Manifest {
+  const modules: CemModule[] = [];
+
+  for (const { pkg, manifest } of sources) {
+    for (const module of manifest.modules ?? []) {
+      modules.push({
+        ...module,
+        path: `${pkg}/${module.path}`,
+      });
+    }
+  }
+
+  return {
+    schemaVersion: sources[0]?.manifest.schemaVersion ?? "1.0.0",
+    readme: "",
+    modules,
+  };
+}
+
+export default program
+  .command("cem")
+  .description(
+    "Aggregate the Custom Elements Manifests of all published Auro components into a single file",
+  )
+  .option("--aggregate", "Fetch and merge every component manifest", true)
+  .option(
+    "-o, --output <file>",
+    "Path to write the aggregated manifest",
+    "custom-elements.aggregate.json",
+  )
+  .action(async (options) => {
+    const spinner = ora(
+      `Fetching manifests for ${AURO_COMPONENT_PACKAGES.length} components...`,
+    ).start();
+
+    const results = await Promise.allSettled(
+      AURO_COMPONENT_PACKAGES.map(async (pkg) => ({
+        pkg,
+        manifest: await fetchManifest(pkg),
+      })),
+    );
+
+    const sources: ManifestSource[] = [];
+    for (const result of results) {
+      if (result.status === "fulfilled" && result.value.manifest) {
+        sources.push({
+          pkg: result.value.pkg,
+          manifest: result.value.manifest,
+        });
+      }
+    }
+
+    if (sources.length === 0) {
+      spinner.fail("No component manifests could be fetched.");
+      process.exit(1);
+    }
+
+    spinner.text = "Merging manifests...";
+    const aggregate = mergeManifests(sources);
+
+    const outputPath = path.resolve(process.cwd(), options.output);
+    try {
+      await writeFile(
+        outputPath,
+        `${JSON.stringify(aggregate, null, 2)}\n`,
+        "utf-8",
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      spinner.fail(`Failed to write ${options.output}: ${message}`);
+      process.exit(1);
+    }
+
+    spinner.succeed(
+      `Aggregated ${sources.length}/${AURO_COMPONENT_PACKAGES.length} component manifests (${aggregate.modules?.length ?? 0} modules) to ${options.output}`,
+    );
+  });

--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -1,0 +1,35 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { program } from "commander";
+import ora from "ora";
+import { AURO_CONTEXT } from "#static/auroContext.js";
+
+export default program
+  .command("context")
+  .description(
+    "Generate an AI assistant context document for the Auro Design System",
+  )
+  .option(
+    "-o, --output <path>",
+    "Write context to a file instead of stdout (e.g. AURO_CONTEXT.md)",
+  )
+  .action(async (options) => {
+    if (options.output) {
+      const spinner = ora(`Writing context to ${options.output}...`).start();
+      try {
+        const outputPath = path.resolve(process.cwd(), options.output);
+        await fs.writeFile(outputPath, AURO_CONTEXT, "utf-8");
+        spinner.succeed(`Auro context written to ${options.output}`);
+        console.log(
+          "\nPaste this file into your AI coding tool (Claude, Cursor, Copilot, etc.) to prime it on Auro components.",
+        );
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : String(error);
+        spinner.fail(`Failed to write context: ${message}`);
+        process.exit(1);
+      }
+    } else {
+      process.stdout.write(AURO_CONTEXT);
+    }
+  });

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import "#commands/check-commits.ts";
 import "#commands/pr-release.ts";
 import "#commands/test.js";
 import "#commands/agent.ts";
+import "#commands/cem.ts";
 import "#commands/context.ts";
 import "#commands/docs.ts";
 import "#commands/ado.ts";

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import "#commands/check-commits.ts";
 import "#commands/pr-release.ts";
 import "#commands/test.js";
 import "#commands/agent.ts";
+import "#commands/context.ts";
 import "#commands/docs.ts";
 import "#commands/ado.ts";
 import "#commands/rc-workflow.ts";

--- a/src/static/auroComponents.ts
+++ b/src/static/auroComponents.ts
@@ -1,0 +1,42 @@
+/**
+ * The published Auro component packages that ship a Custom Elements Manifest
+ * (`custom-elements.json`) at their package root.
+ *
+ * Keep this list in sync with the components published under the
+ * `@aurodesignsystem/` npm scope. Used by the `auro cem --aggregate` command
+ * to fetch and merge each component's manifest into a single file.
+ */
+export const AURO_COMPONENT_PACKAGES = [
+  "@aurodesignsystem/auro-accordion",
+  "@aurodesignsystem/auro-alert",
+  "@aurodesignsystem/auro-avatar",
+  "@aurodesignsystem/auro-background",
+  "@aurodesignsystem/auro-backtotop",
+  "@aurodesignsystem/auro-badge",
+  "@aurodesignsystem/auro-banner",
+  "@aurodesignsystem/auro-button",
+  "@aurodesignsystem/auro-card",
+  "@aurodesignsystem/auro-carousel",
+  "@aurodesignsystem/auro-datetime",
+  "@aurodesignsystem/auro-dialog",
+  "@aurodesignsystem/auro-drawer",
+  "@aurodesignsystem/auro-flight",
+  "@aurodesignsystem/auro-flightline",
+  "@aurodesignsystem/auro-formkit",
+  "@aurodesignsystem/auro-header",
+  "@aurodesignsystem/auro-hyperlink",
+  "@aurodesignsystem/auro-icon",
+  "@aurodesignsystem/auro-loader",
+  "@aurodesignsystem/auro-lockup",
+  "@aurodesignsystem/auro-nav",
+  "@aurodesignsystem/auro-pane",
+  "@aurodesignsystem/auro-popover",
+  "@aurodesignsystem/auro-sidenav",
+  "@aurodesignsystem/auro-skeleton",
+  "@aurodesignsystem/auro-slideshow",
+  "@aurodesignsystem/auro-table",
+  "@aurodesignsystem/auro-tabs",
+  "@aurodesignsystem/auro-tail",
+  "@aurodesignsystem/auro-toast",
+  "@aurodesignsystem/auro-tokenlist",
+];

--- a/src/static/auroComponents.ts
+++ b/src/static/auroComponents.ts
@@ -1,10 +1,11 @@
 /**
- * The published Auro component packages that ship a Custom Elements Manifest
- * (`custom-elements.json`) at their package root.
+ * Candidate Auro component packages to check for a Custom Elements Manifest
+ * (`custom-elements.json`) at their package root. Not every component publishes
+ * one yet — the `auro cem` command fetches each and skips those that 404, so
+ * this list can safely include components ahead of their CEM adoption.
  *
  * Keep this list in sync with the components published under the
- * `@aurodesignsystem/` npm scope. Used by the `auro cem --aggregate` command
- * to fetch and merge each component's manifest into a single file.
+ * `@aurodesignsystem/` npm scope.
  */
 export const AURO_COMPONENT_PACKAGES = [
   "@aurodesignsystem/auro-accordion",

--- a/src/static/auroContext.ts
+++ b/src/static/auroContext.ts
@@ -88,6 +88,7 @@ Auro is Alaska Airlines' design system built on Web Components (Custom Elements 
 | \`<auro-tabs>\` | \`@aurodesignsystem/auro-tabs\` | Tabbed content panels |
 | \`<auro-tail>\` | \`@aurodesignsystem/auro-tail\` | Alaska, Hawaiian, and partner airline tail graphics |
 | \`<auro-toast>\` | \`@aurodesignsystem/auro-toast\` | Transient notification toast |
+| \`<auro-tokenlist>\` | \`@aurodesignsystem/auro-tokenlist\` | Design token display utilities |
 
 ## Common Patterns
 

--- a/src/static/auroContext.ts
+++ b/src/static/auroContext.ts
@@ -1,0 +1,164 @@
+export const AURO_CONTEXT = `# Auro Design System — AI Assistant Context
+Alaska Airlines open-source design system | https://auro.alaskaair.com
+
+## What is Auro?
+Auro is Alaska Airlines' design system built on Web Components (Custom Elements v1) using the Lit library.
+- npm scope: \`@aurodesignsystem/\` (current), \`@alaskaairux/\` (legacy)
+- Framework-agnostic: works with React, Angular, Vue, Svelte, or plain HTML
+- Each component is a separate npm package
+- All components use the \`<auro-*>\` custom element tag
+
+## Rules for Writing Auro Code
+
+1. **Use \`<auro-*>\` custom element tags — never plain HTML equivalents**
+   - ✗ \`<button>\` → ✓ \`<auro-button>\`
+   - ✗ \`<a href="...">\` → ✓ \`<auro-hyperlink href="...">\`
+   - ✗ \`<input>\` → ✓ \`<auro-input>\` (from auro-formkit)
+
+2. **Install and register each component before use**
+   \`\`\`bash
+   npm install @aurodesignsystem/auro-button
+   \`\`\`
+   \`\`\`js
+   import "@aurodesignsystem/auro-button"; // registers <auro-button> globally
+   \`\`\`
+
+3. **Props are HTML attributes in templates; camelCase properties in JS**
+   \`\`\`html
+   <auro-button disabled loading>Save</auro-button>
+   \`\`\`
+   \`\`\`js
+   document.querySelector('auro-button').loading = true;
+   \`\`\`
+
+4. **Content goes in named slots, not innerHTML**
+   \`\`\`html
+   <auro-dialog>
+     <span slot="header">Title</span>
+     <div slot="content">Body content here</div>
+   </auro-dialog>
+   \`\`\`
+
+5. **Design tokens are CSS custom properties**
+   \`\`\`bash
+   npm install @aurodesignsystem/design-tokens
+   \`\`\`
+   \`\`\`css
+   @import "@aurodesignsystem/design-tokens/dist/themes/CSSCustomProperties--bundled.css";
+   \`\`\`
+   Token naming: \`--ds-color-*\`, \`--ds-size-*\`, \`--ds-font-*\`, \`--ds-border-*\`
+
+## Component Reference
+
+| Element Tag | Package | Description |
+|---|---|---|
+| \`<auro-accordion>\` | \`@aurodesignsystem/auro-accordion\` | Expandable content sections |
+| \`<auro-alert>\` | \`@aurodesignsystem/auro-alert\` | Inline status messages: error, warning, success, information |
+| \`<auro-avatar>\` | \`@aurodesignsystem/auro-avatar\` | User or entity avatar |
+| \`<auro-background>\` | \`@aurodesignsystem/auro-background\` | Themed background wrapper |
+| \`<auro-backtotop>\` | \`@aurodesignsystem/auro-backtotop\` | Scroll-to-top button |
+| \`<auro-badge>\` | \`@aurodesignsystem/auro-badge\` | Status or count badge |
+| \`<auro-banner>\` | \`@aurodesignsystem/auro-banner\` | Full-width promotional banner |
+| \`<auro-button>\` | \`@aurodesignsystem/auro-button\` | Interactive button; supports \`loading\`, \`disabled\`, \`shape\` |
+| \`<auro-card>\` | \`@aurodesignsystem/auro-card\` | Content card container |
+| \`<auro-carousel>\` | \`@aurodesignsystem/auro-carousel\` | Horizontally scrollable carousel |
+| \`<auro-datetime>\` | \`@aurodesignsystem/auro-datetime\` | Localized date and time formatting |
+| \`<auro-dialog>\` | \`@aurodesignsystem/auro-dialog\` | Modal dialog; slots: header, content, footer |
+| \`<auro-drawer>\` | \`@aurodesignsystem/auro-drawer\` | Slide-in panel; slots: header, content, footer |
+| \`<auro-flight>\` | \`@aurodesignsystem/auro-flight\` | Flight segment display (origin, destination, stops) |
+| \`<auro-flightline>\` | \`@aurodesignsystem/auro-flightline\` | Visual flight path/stop indicator |
+| \`<auro-input>\` | \`@aurodesignsystem/auro-formkit\` | Text input field |
+| \`<auro-select>\` | \`@aurodesignsystem/auro-formkit\` | Select/dropdown |
+| \`<auro-datepicker>\` | \`@aurodesignsystem/auro-formkit\` | Date picker input |
+| \`<auro-combobox>\` | \`@aurodesignsystem/auro-formkit\` | Combobox with search |
+| \`<auro-checkbox>\` | \`@aurodesignsystem/auro-formkit\` | Checkbox input |
+| \`<auro-radio>\` | \`@aurodesignsystem/auro-formkit\` | Radio button input |
+| \`<auro-header>\` | \`@aurodesignsystem/auro-header\` | Page/section heading |
+| \`<auro-hyperlink>\` | \`@aurodesignsystem/auro-hyperlink\` | Accessible anchor link |
+| \`<auro-icon>\` | \`@aurodesignsystem/auro-icon\` | Alaska Airlines icon: \`category\` + \`name\` attributes |
+| \`<auro-loader>\` | \`@aurodesignsystem/auro-loader\` | Loading spinner |
+| \`<auro-lockup>\` | \`@aurodesignsystem/auro-lockup\` | Image + text layout lockup |
+| \`<auro-nav>\` | \`@aurodesignsystem/auro-nav\` | Breadcrumb / secondary navigation |
+| \`<auro-pane>\` | \`@aurodesignsystem/auro-pane\` | Selectable pricing or option pane |
+| \`<auro-popover>\` | \`@aurodesignsystem/auro-popover\` | Tooltip-style popover |
+| \`<auro-sidenav>\` | \`@aurodesignsystem/auro-sidenav\` | Vertical side navigation |
+| \`<auro-skeleton>\` | \`@aurodesignsystem/auro-skeleton\` | Loading placeholder skeleton |
+| \`<auro-slideshow>\` | \`@aurodesignsystem/auro-slideshow\` | Image/content slideshow |
+| \`<auro-table>\` | \`@aurodesignsystem/auro-table\` | Accessible data table |
+| \`<auro-tabs>\` | \`@aurodesignsystem/auro-tabs\` | Tabbed content panels |
+| \`<auro-tail>\` | \`@aurodesignsystem/auro-tail\` | Alaska, Hawaiian, and partner airline tail graphics |
+| \`<auro-toast>\` | \`@aurodesignsystem/auro-toast\` | Transient notification toast |
+
+## Common Patterns
+
+### Button (default, secondary, tertiary)
+\`\`\`html
+<auro-button>Primary</auro-button>
+<auro-button variant="secondary">Secondary</auro-button>
+<auro-button variant="tertiary">Tertiary</auro-button>
+<auro-button loading>Saving...</auro-button>
+\`\`\`
+
+### Alert
+\`\`\`html
+<auro-alert type="success">Changes saved.</auro-alert>
+<auro-alert type="error">Something went wrong.</auro-alert>
+<auro-alert type="warning">Please review before continuing.</auro-alert>
+<auro-alert type="information">Your flight departs at 9am.</auro-alert>
+\`\`\`
+
+### Form inputs (auro-formkit)
+\`\`\`js
+import "@aurodesignsystem/auro-formkit";
+\`\`\`
+\`\`\`html
+<auro-input label="First name" required></auro-input>
+<auro-input label="Email" type="email"></auro-input>
+<auro-select label="Seat preference">
+  <auro-menu>
+    <auro-menuoption value="window">Window</auro-menuoption>
+    <auro-menuoption value="aisle">Aisle</auro-menuoption>
+  </auro-menu>
+</auro-select>
+\`\`\`
+
+### Icon
+\`\`\`html
+<auro-icon category="interface" name="arrow-right"></auro-icon>
+<auro-icon category="terminal" name="plane-side" customSize style="width: 48px"></auro-icon>
+\`\`\`
+
+### Hyperlink
+\`\`\`html
+<auro-hyperlink href="/flights">View flights</auro-hyperlink>
+<auro-hyperlink href="https://example.com" target="_blank">External link</auro-hyperlink>
+\`\`\`
+
+### Dialog (modal)
+\`\`\`js
+document.querySelector('#confirmDialog').show();
+\`\`\`
+\`\`\`html
+<auro-dialog id="confirmDialog">
+  <span slot="header">Confirm booking</span>
+  <div slot="content">Are you sure you want to book this flight?</div>
+  <div slot="footer">
+    <auro-button>Confirm</auro-button>
+    <auro-button variant="secondary">Cancel</auro-button>
+  </div>
+</auro-dialog>
+\`\`\`
+
+## Accessibility Notes
+- Use the \`ariaLabel\` slot on \`<auro-button>\` for icon-only buttons
+- \`<auro-hyperlink>\` adds rel="noopener noreferrer" automatically for external links
+- All \`auro-formkit\` components handle aria-invalid and error messaging built-in
+- All components meet WCAG 2.1 AA
+
+## Documentation
+- Component docs: https://auro.alaskaair.com
+- Component status: https://auro.alaskaair.com/component-status
+- Design tokens: https://auro.alaskaair.com/getting-started/developers/token-usage
+- Contributing: https://auro.alaskaair.com/getting-started/developers/contributing
+- GitHub: https://github.com/AlaskaAirlines
+`;

--- a/src/static/auroContext.ts
+++ b/src/static/auroContext.ts
@@ -46,7 +46,7 @@ Auro is Alaska Airlines' design system built on Web Components (Custom Elements 
    \`\`\`css
    @import "@aurodesignsystem/design-tokens/dist/themes/CSSCustomProperties--bundled.css";
    \`\`\`
-   Token naming: \`--ds-color-*\`, \`--ds-size-*\`, \`--ds-font-*\`, \`--ds-border-*\`
+   Token naming: \`--ds-basic-*\` and \`--ds-advanced-*\` (e.g. \`--ds-advanced-color-*\`, \`--ds-basic-color-*\`)
 
 ## Component Reference
 
@@ -78,8 +78,8 @@ Auro is Alaska Airlines' design system built on Web Components (Custom Elements 
 | \`<auro-icon>\` | \`@aurodesignsystem/auro-icon\` | Alaska Airlines icon: \`category\` + \`name\` attributes |
 | \`<auro-loader>\` | \`@aurodesignsystem/auro-loader\` | Loading spinner |
 | \`<auro-lockup>\` | \`@aurodesignsystem/auro-lockup\` | Image + text layout lockup |
-| \`<auro-nav>\` | \`@aurodesignsystem/auro-nav\` | Breadcrumb / secondary navigation |
-| \`<auro-pane>\` | \`@aurodesignsystem/auro-pane\` | Selectable pricing or option pane |
+| \`<auro-nav>\` | \`@aurodesignsystem/auro-nav\` | Secondary navigation aid (relation to higher-level pages) |
+| \`<auro-pane>\` | \`@aurodesignsystem/auro-pane\` | Selectable shoulder dates with associated prices |
 | \`<auro-popover>\` | \`@aurodesignsystem/auro-popover\` | Tooltip-style popover |
 | \`<auro-sidenav>\` | \`@aurodesignsystem/auro-sidenav\` | Vertical side navigation |
 | \`<auro-skeleton>\` | \`@aurodesignsystem/auro-skeleton\` | Loading placeholder skeleton |
@@ -108,13 +108,18 @@ Auro is Alaska Airlines' design system built on Web Components (Custom Elements 
 \`\`\`
 
 ### Form inputs (auro-formkit)
+auro-formkit has no root export — always import the specific sub-component.
+The field label is a **slot**, not an attribute.
 \`\`\`js
-import "@aurodesignsystem/auro-formkit";
+import "@aurodesignsystem/auro-formkit/auro-input";
+import "@aurodesignsystem/auro-formkit/auro-select";
 \`\`\`
 \`\`\`html
-<auro-input label="First name" required></auro-input>
-<auro-input label="Email" type="email"></auro-input>
-<auro-select label="Seat preference">
+<auro-input required>
+  <span slot="label">First name</span>
+</auro-input>
+<auro-select>
+  <span slot="label">Seat preference</span>
   <auro-menu>
     <auro-menuoption value="window">Window</auro-menuoption>
     <auro-menuoption value="aisle">Aisle</auro-menuoption>
@@ -123,9 +128,10 @@ import "@aurodesignsystem/auro-formkit";
 \`\`\`
 
 ### Icon
+Set \`category\` and \`name\`. Icon names are exact — check the icon library for the correct name.
 \`\`\`html
 <auro-icon category="interface" name="arrow-right"></auro-icon>
-<auro-icon category="terminal" name="plane-side" customSize style="width: 48px"></auro-icon>
+<auro-icon category="terminal" name="plane-side-fill"></auro-icon>
 \`\`\`
 
 ### Hyperlink

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,6 +34,7 @@
       "#configs/*": ["src/configs/*"],
       "#commands/*": ["src/commands/*"],
       "#scripts/*": ["src/scripts/*"],
+      "#static/*": ["src/static/*"],
       "#utils/*": ["src/utils/*"]
     },
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */


### PR DESCRIPTION
> **Note:** Stacked on #296 (adds the `#static/*` import alias this command relies on). Base will be retargeted to `dev` once #296 merges. Review the [compare against `feat/context-command`](https://github.com/AlaskaAirlines/auro-cli/compare/feat/context-command...feat/cem-aggregate) for this PR's isolated diff.

## Summary

Adds a new `auro cem` command that fetches each published Auro component's `custom-elements.json` from unpkg and merges them into a single aggregated Custom Elements Manifest.

An aggregated manifest gives IDEs, documentation tooling, and AI assistants **one** machine-readable index of every Auro component's API — props, attributes, slots, CSS parts, and events — instead of 30+ separate files.

## Usage

```bash
# Write custom-elements.aggregate.json to the current directory
auro cem

# Write to a specific path (e.g. for the docs site to consume)
auro cem --output dist/custom-elements.aggregate.json
```

## Behavior

- Fetches `https://unpkg.com/<pkg>/custom-elements.json` for each component in `src/static/auroComponents.ts`.
- Components that don't publish a manifest are **skipped with a warning** (not fatal) — today only a subset of components publish a CEM, so this is expected.
- Each source module's `path` is namespaced with its package (e.g. `@aurodesignsystem/auro-button/src/auro-button.js`) so paths stay unique and every declaration is traceable to its component.

## Testing

- `npm run build` succeeds (TypeScript typechecks clean).
- Merge logic verified against real `auro-button` (7 modules) and `auro-card` (4 modules) manifests → 11 correctly namespaced modules, valid CEM JSON.
- Network failures and non-200 responses are handled gracefully with per-package warnings.

## Follow-ups

- Only ~6 components currently publish a CEM; a companion change to the component template (WC-Generator) would broaden coverage.
- A docs-site CI step could publish the aggregated manifest at a stable URL for consumers.

## Summary by Sourcery

Add a CLI command to aggregate Custom Elements Manifests for all published Auro components into a single output file.

New Features:
- Introduce the `auro cem` command to fetch and merge Custom Elements Manifests from all configured Auro component packages into one aggregated manifest.

Enhancements:
- Namespace manifest module paths by package in the aggregated output so declarations remain unique and traceable to their source component.
- Register the new `cem` command with the main CLI entrypoint and centralize the list of Auro component packages that publish manifests.

Documentation:
- Document the `auro cem` command, its options, and usage examples in the README.