### PR TITLE
feat(component): add auro component command for API lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,11 @@ auro dev --open src/
 ```
 
 `auro component <name>`
-Looks up a single Auro component's API — attributes, slots, events, and CSS parts — from its published Custom Elements Manifest. Useful for humans and for AI coding assistants that call the CLI in a tool-use loop to avoid guessing an API.
+Looks up a single Auro component's API — attributes, properties/methods, slots, events, and CSS parts — from its published Custom Elements Manifest. Useful for humans and for AI coding assistants that call the CLI in a tool-use loop to avoid guessing an API.
 
 #### Options
 
+- `-t, --tag <version>` npm dist-tag or version to look up (default: `latest`).
 - `--json` Output the raw manifest declaration(s) as JSON instead of formatted text.
 
 #### Examples
@@ -74,6 +75,13 @@ Look up a component (name is normalized, so all of these work):
 auro component button
 auro component auro-button
 auro component @aurodesignsystem/auro-button
+```
+
+Look up a specific version or dist-tag:
+
+```
+auro component auro-button --tag beta
+auro component auro-button --tag 11.0.0
 ```
 
 Get machine-readable output:

--- a/README.md
+++ b/README.md
@@ -58,3 +58,26 @@ Open the server to a specific directory:
 ```
 auro dev --open src/
 ```
+
+`auro component <name>`
+Looks up a single Auro component's API — attributes, slots, events, and CSS parts — from its published Custom Elements Manifest. Useful for humans and for AI coding assistants that call the CLI in a tool-use loop to avoid guessing an API.
+
+#### Options
+
+- `--json` Output the raw manifest declaration(s) as JSON instead of formatted text.
+
+#### Examples
+
+Look up a component (name is normalized, so all of these work):
+
+```
+auro component button
+auro component auro-button
+auro component @aurodesignsystem/auro-button
+```
+
+Get machine-readable output:
+
+```
+auro component auro-button --json
+```

--- a/src/commands/component.ts
+++ b/src/commands/component.ts
@@ -27,6 +27,7 @@ interface CemMember {
   privacy?: string;
   static?: boolean;
   type?: CemType;
+  default?: string;
   description?: string;
   deprecated?: Deprecated;
   return?: { type?: CemType };
@@ -178,9 +179,10 @@ function formatDeclaration(pkg: string, decl: CemDeclaration): string {
         const label = isMethod ? `${m.name}()` : m.name;
         const typeText = isMethod ? m.return?.type?.text : m.type?.text;
         const type = typeText ? ` {${clean(typeText)}}` : "";
+        const def = !isMethod && m.default ? ` = ${clean(m.default)}` : "";
         return [
           label,
-          `${clean(m.description)}${type}${deprecatedTag(m.deprecated)}`.trim(),
+          `${clean(m.description)}${type}${def}${deprecatedTag(m.deprecated)}`.trim(),
         ];
       }),
     ),

--- a/src/commands/component.ts
+++ b/src/commands/component.ts
@@ -1,0 +1,213 @@
+import process from "node:process";
+import { Logger } from "@aurodesignsystem/auro-library/scripts/utils/logger.mjs";
+import { program } from "commander";
+import ora from "ora";
+
+const UNPKG_BASE = "https://unpkg.com";
+const SCOPE = "@aurodesignsystem";
+
+interface CemType {
+  text?: string;
+}
+
+interface CemAttribute {
+  name: string;
+  type?: CemType;
+  default?: string;
+  description?: string;
+}
+
+interface CemSlot {
+  name: string;
+  description?: string;
+}
+
+interface CemEvent {
+  name: string;
+  type?: CemType;
+  description?: string;
+}
+
+interface CemNamed {
+  name: string;
+  description?: string;
+}
+
+interface CemDeclaration {
+  kind: string;
+  name: string;
+  tagName?: string;
+  customElement?: boolean;
+  description?: string;
+  summary?: string;
+  attributes?: CemAttribute[];
+  slots?: CemSlot[];
+  events?: CemEvent[];
+  cssParts?: CemNamed[];
+  cssProperties?: CemNamed[];
+}
+
+interface CemModule {
+  declarations?: CemDeclaration[];
+}
+
+interface Manifest {
+  modules?: CemModule[];
+}
+
+/**
+ * Normalize a user-supplied component name into a full npm package name.
+ * Accepts "button", "auro-button", or "@aurodesignsystem/auro-button".
+ */
+function toPackageName(name: string): string {
+  if (name.startsWith(`${SCOPE}/`)) {
+    return name;
+  }
+  if (name.startsWith("auro-")) {
+    return `${SCOPE}/${name}`;
+  }
+  return `${SCOPE}/auro-${name}`;
+}
+
+/**
+ * Collapse whitespace (including embedded newlines from JSDoc) to keep each
+ * entry on a single line so the aligned columns don't break.
+ */
+function clean(text: string | undefined): string {
+  return (text ?? "").replace(/\s+/gu, " ").trim();
+}
+
+/**
+ * Render a two-column list (name → description) with aligned padding.
+ */
+function renderList(rows: Array<[string, string]>): string {
+  if (rows.length === 0) {
+    return "  (none)";
+  }
+  const width = Math.max(...rows.map(([label]) => label.length));
+  return rows
+    .map(([label, desc]) => `  ${label.padEnd(width)}  ${desc}`.trimEnd())
+    .join("\n");
+}
+
+/**
+ * Format one custom-element declaration into a readable summary.
+ */
+function formatDeclaration(pkg: string, decl: CemDeclaration): string {
+  const lines: string[] = [];
+  const tag = decl.tagName ?? decl.name;
+
+  lines.push(`${tag}  (${pkg})`);
+  const description = decl.summary || decl.description;
+  if (description) {
+    lines.push(description.trim());
+  }
+
+  lines.push("");
+  lines.push("Install:");
+  lines.push(`  npm i ${pkg}`);
+  lines.push(`  import "${pkg}";`);
+
+  const attributes = decl.attributes ?? [];
+  lines.push("");
+  lines.push(`Attributes (${attributes.length}):`);
+  lines.push(
+    renderList(
+      attributes.map((a) => {
+        const type = a.type?.text ? ` {${clean(a.type.text)}}` : "";
+        const def = a.default ? ` = ${clean(a.default)}` : "";
+        return [a.name, `${clean(a.description)}${type}${def}`.trim()];
+      }),
+    ),
+  );
+
+  const slots = decl.slots ?? [];
+  lines.push("");
+  lines.push(`Slots (${slots.length}):`);
+  lines.push(
+    renderList(slots.map((s) => [s.name || "(default)", clean(s.description)])),
+  );
+
+  const events = decl.events ?? [];
+  lines.push("");
+  lines.push(`Events (${events.length}):`);
+  lines.push(
+    renderList(
+      events.map((e) => {
+        const type = e.type?.text ? ` {${clean(e.type.text)}}` : "";
+        return [e.name, `${clean(e.description)}${type}`.trim()];
+      }),
+    ),
+  );
+
+  const cssParts = decl.cssParts ?? [];
+  if (cssParts.length > 0) {
+    lines.push("");
+    lines.push(`CSS Parts (${cssParts.length}):`);
+    lines.push(renderList(cssParts.map((p) => [p.name, clean(p.description)])));
+  }
+
+  const cssProps = decl.cssProperties ?? [];
+  if (cssProps.length > 0) {
+    lines.push("");
+    lines.push(`CSS Custom Properties (${cssProps.length}):`);
+    lines.push(renderList(cssProps.map((p) => [p.name, clean(p.description)])));
+  }
+
+  return lines.join("\n");
+}
+
+export default program
+  .command("component <name>")
+  .description(
+    "Look up an Auro component's API (attributes, slots, events, CSS parts) from its published Custom Elements Manifest",
+  )
+  .option("--json", "Output the raw manifest declaration(s) as JSON", false)
+  .action(async (name, options) => {
+    const pkg = toPackageName(name);
+    const spinner = ora(`Fetching ${pkg}...`).start();
+
+    let manifest: Manifest;
+    try {
+      const response = await fetch(`${UNPKG_BASE}/${pkg}/custom-elements.json`);
+      if (response.status === 404) {
+        spinner.fail(
+          `No custom-elements.json published for ${pkg}. It may not exist or may not publish a manifest yet.`,
+        );
+        process.exit(1);
+      }
+      if (!response.ok) {
+        spinner.fail(`Failed to fetch ${pkg} (HTTP ${response.status}).`);
+        process.exit(1);
+      }
+      manifest = (await response.json()) as Manifest;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      spinner.fail(`Request failed for ${pkg}: ${message}`);
+      process.exit(1);
+      return;
+    }
+
+    const declarations = (manifest.modules ?? [])
+      .flatMap((module) => module.declarations ?? [])
+      .filter((decl) => decl.customElement);
+
+    if (declarations.length === 0) {
+      spinner.fail(`No custom elements found in the manifest for ${pkg}.`);
+      process.exit(1);
+    }
+
+    spinner.succeed(
+      `${pkg} — ${declarations.length} custom element${declarations.length === 1 ? "" : "s"}`,
+    );
+
+    if (options.json) {
+      process.stdout.write(`${JSON.stringify(declarations, null, 2)}\n`);
+      return;
+    }
+
+    process.stdout.write(
+      `\n${declarations.map((decl) => formatDeclaration(pkg, decl)).join("\n\n---\n\n")}\n`,
+    );
+    Logger.info(`\nFull docs: https://auro.alaskaair.com`);
+  });

--- a/src/commands/component.ts
+++ b/src/commands/component.ts
@@ -10,11 +10,26 @@ interface CemType {
   text?: string;
 }
 
+type Deprecated = boolean | string | undefined;
+
 interface CemAttribute {
   name: string;
+  fieldName?: string;
   type?: CemType;
   default?: string;
   description?: string;
+  deprecated?: Deprecated;
+}
+
+interface CemMember {
+  kind: string;
+  name: string;
+  privacy?: string;
+  static?: boolean;
+  type?: CemType;
+  description?: string;
+  deprecated?: Deprecated;
+  return?: { type?: CemType };
 }
 
 interface CemSlot {
@@ -40,7 +55,9 @@ interface CemDeclaration {
   customElement?: boolean;
   description?: string;
   summary?: string;
+  superclass?: { name?: string };
   attributes?: CemAttribute[];
+  members?: CemMember[];
   slots?: CemSlot[];
   events?: CemEvent[];
   cssParts?: CemNamed[];
@@ -57,24 +74,39 @@ interface Manifest {
 
 /**
  * Normalize a user-supplied component name into a full npm package name.
- * Accepts "button", "auro-button", or "@aurodesignsystem/auro-button".
+ * Accepts "button", "auro-button", or "@aurodesignsystem/auro-button" (and
+ * tolerates surrounding whitespace / casing). An explicit scope is respected.
  */
 function toPackageName(name: string): string {
-  if (name.startsWith(`${SCOPE}/`)) {
-    return name;
+  const trimmed = name.trim();
+  if (trimmed.startsWith("@")) {
+    return trimmed;
   }
-  if (name.startsWith("auro-")) {
-    return `${SCOPE}/${name}`;
+  const lower = trimmed.toLowerCase();
+  if (lower.startsWith("auro-")) {
+    return `${SCOPE}/${lower}`;
   }
-  return `${SCOPE}/auro-${name}`;
+  return `${SCOPE}/auro-${lower}`;
 }
 
 /**
- * Collapse whitespace (including embedded newlines from JSDoc) to keep each
- * entry on a single line so the aligned columns don't break.
+ * Collapse whitespace (including embedded newlines from JSDoc descriptions) to
+ * a single space so aligned columns don't break.
  */
 function clean(text: string | undefined): string {
   return (text ?? "").replace(/\s+/gu, " ").trim();
+}
+
+/**
+ * Render a `[deprecated]` (optionally with a reason) marker.
+ */
+function deprecatedTag(deprecated: Deprecated): string {
+  if (!deprecated) {
+    return "";
+  }
+  return typeof deprecated === "string"
+    ? ` [deprecated: ${clean(deprecated)}]`
+    : " [deprecated]";
 }
 
 /**
@@ -95,13 +127,16 @@ function renderList(rows: Array<[string, string]>): string {
  */
 function formatDeclaration(pkg: string, decl: CemDeclaration): string {
   const lines: string[] = [];
-  const tag = decl.tagName ?? decl.name;
 
-  lines.push(`${tag}  (${pkg})`);
+  lines.push(`${decl.tagName}  (${pkg})`);
   const description = decl.summary || decl.description;
   if (description) {
-    lines.push(description.trim());
+    lines.push(clean(description));
   }
+  const heritage = decl.superclass?.name
+    ? `${decl.name} extends ${decl.superclass.name}`
+    : decl.name;
+  lines.push(`Class: ${heritage}`);
 
   lines.push("");
   lines.push("Install:");
@@ -116,7 +151,37 @@ function formatDeclaration(pkg: string, decl: CemDeclaration): string {
       attributes.map((a) => {
         const type = a.type?.text ? ` {${clean(a.type.text)}}` : "";
         const def = a.default ? ` = ${clean(a.default)}` : "";
-        return [a.name, `${clean(a.description)}${type}${def}`.trim()];
+        return [
+          a.name,
+          `${clean(a.description)}${type}${def}${deprecatedTag(a.deprecated)}`.trim(),
+        ];
+      }),
+    ),
+  );
+
+  // Public properties/methods not already covered by an attribute.
+  const attrFields = new Set(
+    attributes.map((a) => a.fieldName).filter(Boolean) as string[],
+  );
+  const members = (decl.members ?? []).filter(
+    (m) =>
+      (m.privacy === undefined || m.privacy === "public") &&
+      !m.static &&
+      !(m.kind === "field" && attrFields.has(m.name)),
+  );
+  lines.push("");
+  lines.push(`Properties & Methods (${members.length}):`);
+  lines.push(
+    renderList(
+      members.map((m) => {
+        const isMethod = m.kind === "method";
+        const label = isMethod ? `${m.name}()` : m.name;
+        const typeText = isMethod ? m.return?.type?.text : m.type?.text;
+        const type = typeText ? ` {${clean(typeText)}}` : "";
+        return [
+          label,
+          `${clean(m.description)}${type}${deprecatedTag(m.deprecated)}`.trim(),
+        ];
       }),
     ),
   );
@@ -160,45 +225,53 @@ function formatDeclaration(pkg: string, decl: CemDeclaration): string {
 export default program
   .command("component <name>")
   .description(
-    "Look up an Auro component's API (attributes, slots, events, CSS parts) from its published Custom Elements Manifest",
+    "Look up an Auro component's API (attributes, properties, slots, events, CSS parts) from its published Custom Elements Manifest",
+  )
+  .option(
+    "-t, --tag <version>",
+    "npm dist-tag or version to look up (default: latest)",
   )
   .option("--json", "Output the raw manifest declaration(s) as JSON", false)
   .action(async (name, options) => {
     const pkg = toPackageName(name);
-    const spinner = ora(`Fetching ${pkg}...`).start();
+    const target = options.tag ? `${pkg}@${options.tag}` : pkg;
+    const spinner = ora(`Fetching ${target}...`).start();
 
     let manifest: Manifest;
     try {
-      const response = await fetch(`${UNPKG_BASE}/${pkg}/custom-elements.json`);
+      const response = await fetch(
+        `${UNPKG_BASE}/${target}/custom-elements.json`,
+      );
       if (response.status === 404) {
         spinner.fail(
-          `No custom-elements.json published for ${pkg}. It may not exist or may not publish a manifest yet.`,
+          `No custom-elements.json published for ${target}. It may not exist or may not publish a manifest yet.`,
         );
         process.exit(1);
       }
       if (!response.ok) {
-        spinner.fail(`Failed to fetch ${pkg} (HTTP ${response.status}).`);
+        spinner.fail(`Failed to fetch ${target} (HTTP ${response.status}).`);
         process.exit(1);
       }
       manifest = (await response.json()) as Manifest;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      spinner.fail(`Request failed for ${pkg}: ${message}`);
+      spinner.fail(`Request failed for ${target}: ${message}`);
       process.exit(1);
-      return;
     }
 
+    // Only real registered elements — a declaration can be customElement: true
+    // yet be an internal base class with no tagName.
     const declarations = (manifest.modules ?? [])
       .flatMap((module) => module.declarations ?? [])
-      .filter((decl) => decl.customElement);
+      .filter((decl) => decl.customElement && decl.tagName);
 
     if (declarations.length === 0) {
-      spinner.fail(`No custom elements found in the manifest for ${pkg}.`);
+      spinner.fail(`No registered custom elements found for ${target}.`);
       process.exit(1);
     }
 
     spinner.succeed(
-      `${pkg} — ${declarations.length} custom element${declarations.length === 1 ? "" : "s"}`,
+      `${target} — ${declarations.length} custom element${declarations.length === 1 ? "" : "s"}`,
     );
 
     if (options.json) {
@@ -209,5 +282,5 @@ export default program
     process.stdout.write(
       `\n${declarations.map((decl) => formatDeclaration(pkg, decl)).join("\n\n---\n\n")}\n`,
     );
-    Logger.info(`\nFull docs: https://auro.alaskaair.com`);
+    Logger.info("\nFull docs: https://auro.alaskaair.com");
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import "#commands/check-commits.ts";
 import "#commands/pr-release.ts";
 import "#commands/test.js";
 import "#commands/agent.ts";
+import "#commands/component.ts";
 import "#commands/docs.ts";
 import "#commands/ado.ts";
 import "#commands/rc-workflow.ts";


### PR DESCRIPTION
Related ADO story: [AB#1592465](https://itsals.visualstudio.com/5e9f12eb-f830-406f-bee9-be25938f7aaa/_workitems/edit/1592465)

## Summary

Adds `auro component <name>` — a per-component API lookup that fetches a single Auro component's published Custom Elements Manifest (`custom-elements.json`) and prints its API: attributes, slots, events, and CSS parts, with an install snippet.

```bash
auro component button
auro component auro-button
auro component @aurodesignsystem/auro-button   # name is normalized
auro component auro-button --json              # raw declarations for tooling
```

## Why

When a developer (or their AI coding assistant) is building with Auro, the assistant often can't recall a component's exact attributes and guesses — producing broken markup. This command gives a fast, authoritative lookup an AI tool can call in its tool-use loop, or a human can run at the shell, instead of scraping the docsite.

It's the Auro equivalent of Meta's Astryx `npx astryx component Button`, and closes the biggest remaining parity gap for AI-readiness. It reuses data we already publish (the CEM on npm/unpkg) — no new infrastructure.

## Changes

- `src/commands/component.ts` — the command (fetches from unpkg, parses the CEM, formats output; `--json` for machine consumption)
- `src/index.ts` — registers the command
- `README.md` — documents it

## Testing

- `npm run build` succeeds
- `auro component button` fetches auro-button's manifest and prints 22 attributes with types/defaults/descriptions (verified against live unpkg)
- Graceful handling of unknown components and network failures (clear message, non-zero exit)

## Notes

- Independent of the `auro context` (#296) and `auro cem` (#297) PRs — branches off `dev`, no shared files.
- Only components that publish a `custom-elements.json` return data today; coverage grows as more components adopt it (see WC-Generator #637).