### PR TITLE
ci: update Node.js version and npm upgrade command for Trusted Publishing AB#1597898

### DIFF
--- a/.github/workflows/pr-release.yml
+++ b/.github/workflows/pr-release.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22 # Trusted Publishing (OIDC) requires Node >= 22.14
           registry-url: 'https://registry.npmjs.org'
       - name: Install dependencies
         run: npm clean-install
 
       - name: Upgrade npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@12 # Trusted Publishing requires npm >= 11.5.1
       - name: Build
         run: npm run build
       - name: Test

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node-version: [20, 22.22.1]
+        node-version: [22, 24]
 
     steps:
       - uses: actions/checkout@v4
@@ -48,15 +48,17 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22.22.1
+          node-version: 22 # Trusted Publishing (OIDC) requires Node >= 22.14
+          registry-url: 'https://registry.npmjs.org'
       - name: Install dependencies
         run: npm clean-install
-      
+
       - name: Upgrade npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@12 # Trusted Publishing requires npm >= 11.5.1
       - name: Verify the integrity of provenance attestations and registry signatures for installed dependencies
         run: npm audit signatures
       - name: Build


### PR DESCRIPTION
# Alaska Airlines Pull Request

Moves both publish flows to npm Trusted Publishing (OIDC), keeping the existing `NPM_TOKEN` as a fallback for now. `pr-release.yml` (which publishes `@aurodesignsystem-dev/auro-cli`) goes from Node 20 to 22 to clear the OIDC floor, with npm pinned to `npm@12`. `test-and-release.yml` (which publishes `@aurodesignsystem/auro-cli`) runs its release job on Node 22 and `npm@12`, adds `registry-url` and `persist-credentials: false` so semantic-release handles its own git auth, and drops Node 20 from the test matrix so it now runs [22, 24].

No `package.json` change was needed: `provenance: true` and `id-token: write` were already in place, and semantic-release 25 and @semantic-release/npm 13 come in through `@aurodesignsystem/auro-config`.

## Checklist:

- [ ] My update follows the CONTRIBUTING guidelines of this project
- [ ] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Update CI workflows to use Node.js 22+ with npm pinned for Trusted Publishing via OIDC.

Build:
- Adjust GitHub Actions workflows to run tests on Node.js 22 and 24 instead of including Node 20.
- Configure release jobs to use Node.js 22 with npm@12 and npmjs.org registry for compatibility with Trusted Publishing.

CI:
- Disable persisted GitHub credentials in the release workflow so semantic-release manages its own authentication.
- Align pull request release workflow with Trusted Publishing requirements by upgrading to Node.js 22 and npm@12.